### PR TITLE
feat: markdown-itによるMarkdownパーサーを実装

### DIFF
--- a/src/__tests__/directives.test.ts
+++ b/src/__tests__/directives.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { parseDirective, extractCommentContent } from "../directives.js";
+
+describe("parseDirective", () => {
+  it("should parse local directive", () => {
+    const result = parseDirective("layout: Title Slide");
+    expect(result).toEqual({
+      key: "layout",
+      value: "Title Slide",
+      scope: "local",
+    });
+  });
+
+  it("should parse spot directive with _ prefix", () => {
+    const result = parseDirective("_layout: Section Header");
+    expect(result).toEqual({
+      key: "layout",
+      value: "Section Header",
+      scope: "spot",
+    });
+  });
+
+  it("should parse paginate directive", () => {
+    const result = parseDirective("paginate: true");
+    expect(result).toEqual({
+      key: "paginate",
+      value: "true",
+      scope: "local",
+    });
+  });
+
+  it("should parse header directive", () => {
+    const result = parseDirective("header: My Header");
+    expect(result).toEqual({
+      key: "header",
+      value: "My Header",
+      scope: "local",
+    });
+  });
+
+  it("should parse footer directive", () => {
+    const result = parseDirective("_footer: Page Footer");
+    expect(result).toEqual({
+      key: "footer",
+      value: "Page Footer",
+      scope: "spot",
+    });
+  });
+
+  it("should return null for non-directive comment", () => {
+    const result = parseDirective("This is a presenter note");
+    expect(result).toBeNull();
+  });
+
+  it("should return null for unknown key", () => {
+    const result = parseDirective("theme: dark");
+    expect(result).toBeNull();
+  });
+
+  it("should handle whitespace variations", () => {
+    const result = parseDirective("  layout:   Two Content  ");
+    expect(result).toEqual({
+      key: "layout",
+      value: "Two Content",
+      scope: "local",
+    });
+  });
+});
+
+describe("extractCommentContent", () => {
+  it("should extract content from HTML comment", () => {
+    expect(extractCommentContent("<!-- layout: Title Slide -->")).toBe(
+      "layout: Title Slide",
+    );
+  });
+
+  it("should handle extra whitespace", () => {
+    expect(extractCommentContent("<!--   some note   -->")).toBe("some note");
+  });
+
+  it("should return null for non-comment", () => {
+    expect(extractCommentContent("not a comment")).toBeNull();
+  });
+
+  it("should handle multiline comments", () => {
+    expect(extractCommentContent("<!-- line1\nline2 -->")).toBe("line1\nline2");
+  });
+});

--- a/src/__tests__/front-matter.test.ts
+++ b/src/__tests__/front-matter.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { extractFrontMatter } from "../front-matter.js";
+
+describe("extractFrontMatter", () => {
+  it("should parse front matter with all keys", () => {
+    const input = `---
+template: ./templates/company.pptx
+layout: Title Slide
+headingDivider: 2
+author: Taro
+title: My Presentation
+---
+
+# Hello`;
+
+    const { frontMatter, body } = extractFrontMatter(input);
+
+    expect(frontMatter.template).toBe("./templates/company.pptx");
+    expect(frontMatter.layout).toBe("Title Slide");
+    expect(frontMatter.headingDivider).toBe(2);
+    expect(frontMatter.author).toBe("Taro");
+    expect(frontMatter.title).toBe("My Presentation");
+    expect(body).toBe("\n# Hello");
+  });
+
+  it("should parse headingDivider as array", () => {
+    const input = `---
+headingDivider: [1, 2, 3]
+---
+
+Content`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toEqual([1, 2, 3]);
+  });
+
+  it("should parse headingDivider as single number", () => {
+    const input = `---
+headingDivider: 3
+---
+
+Content`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toBe(3);
+  });
+
+  it("should return empty front matter when none exists", () => {
+    const input = "# Hello\n\nWorld";
+    const { frontMatter, body } = extractFrontMatter(input);
+
+    expect(frontMatter).toEqual({});
+    expect(body).toBe(input);
+  });
+
+  it("should parse front matter with only template", () => {
+    const input = `---
+template: ./template.pptx
+---
+
+# Slide`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.template).toBe("./template.pptx");
+    expect(frontMatter.layout).toBeUndefined();
+    expect(frontMatter.headingDivider).toBeUndefined();
+  });
+
+  it("should ignore unknown keys", () => {
+    const input = `---
+template: ./t.pptx
+unknown: value
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.template).toBe("./t.pptx");
+    expect(frontMatter).not.toHaveProperty("unknown");
+  });
+
+  it("should handle empty front matter block", () => {
+    const input = `---
+---
+
+Body`;
+
+    const { frontMatter, body } = extractFrontMatter(input);
+    expect(frontMatter).toEqual({});
+    expect(body).toBe("\nBody");
+  });
+
+  it("should skip comment lines in YAML", () => {
+    const input = `---
+# This is a comment
+template: ./t.pptx
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.template).toBe("./t.pptx");
+  });
+
+  it("should ignore invalid headingDivider values", () => {
+    const input = `---
+headingDivider: abc
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toBeUndefined();
+  });
+
+  it("should filter invalid values in headingDivider array", () => {
+    const input = `---
+headingDivider: [1, x, 3]
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toEqual([1, 3]);
+  });
+
+  it("should reject headingDivider outside 1-6 range", () => {
+    const input = `---
+headingDivider: 0
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toBeUndefined();
+  });
+
+  it("should reject headingDivider value 7", () => {
+    const input = `---
+headingDivider: 7
+---
+
+Body`;
+
+    const { frontMatter } = extractFrontMatter(input);
+    expect(frontMatter.headingDivider).toBeUndefined();
+  });
+});

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect } from "vitest";
+import { parseMarkdown } from "../parser.js";
+
+describe("parseMarkdown", () => {
+  it("should parse a minimal document", () => {
+    const result = parseMarkdown("# Hello");
+
+    expect(result.frontMatter).toEqual({});
+    expect(result.slides).toHaveLength(1);
+    expect(result.slides[0].content[0]).toEqual({
+      type: "heading",
+      level: 1,
+      runs: [{ text: "Hello" }],
+    });
+  });
+
+  it("should parse front matter", () => {
+    const input = `---
+template: ./template.pptx
+title: My Deck
+author: Author
+---
+
+# Title`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.frontMatter.template).toBe("./template.pptx");
+    expect(result.frontMatter.title).toBe("My Deck");
+    expect(result.frontMatter.author).toBe("Author");
+  });
+
+  it("should split slides on ---", () => {
+    const input = `# Slide 1
+
+Body 1
+
+---
+
+# Slide 2
+
+Body 2`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides).toHaveLength(2);
+    expect(result.slides[0].content[0]).toEqual({
+      type: "heading",
+      level: 1,
+      runs: [{ text: "Slide 1" }],
+    });
+    expect(result.slides[1].content[0]).toEqual({
+      type: "heading",
+      level: 1,
+      runs: [{ text: "Slide 2" }],
+    });
+  });
+
+  it("should apply headingDivider", () => {
+    const input = `---
+headingDivider: 2
+---
+
+## Slide 1
+
+Body 1
+
+## Slide 2
+
+Body 2`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides).toHaveLength(2);
+  });
+
+  it("should resolve layout from front matter as default", () => {
+    const input = `---
+layout: Title and Content
+---
+
+# Slide 1
+
+---
+
+# Slide 2`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides[0].layout).toBe("Title and Content");
+    expect(result.slides[1].layout).toBe("Title and Content");
+  });
+
+  it("should resolve local directive and inherit to following slides", () => {
+    const input = `<!-- layout: Two Content -->
+
+# Slide 1
+
+---
+
+# Slide 2
+
+---
+
+# Slide 3`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides[0].layout).toBe("Two Content");
+    expect(result.slides[1].layout).toBe("Two Content");
+    expect(result.slides[2].layout).toBe("Two Content");
+  });
+
+  it("should resolve spot directive only for current slide", () => {
+    const input = `<!-- layout: Two Content -->
+
+# Slide 1
+
+---
+
+<!-- _layout: Title Slide -->
+
+# Slide 2
+
+---
+
+# Slide 3`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides[0].layout).toBe("Two Content");
+    expect(result.slides[1].layout).toBe("Title Slide");
+    expect(result.slides[2].layout).toBe("Two Content");
+  });
+
+  it("should extract presenter notes", () => {
+    const input = `# Title
+
+<!-- Remember to explain this -->
+
+Body text`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.slides[0].notes).toHaveLength(1);
+    expect(result.slides[0].notes[0]).toBe("Remember to explain this");
+  });
+
+  it("should parse the full example from markdown-syntax.md", () => {
+    const input = `---
+template: ./templates/company.pptx
+title: 2024年度 事業報告
+author: 山田太郎
+---
+
+<!-- _layout: Title Slide -->
+
+# 2024年度 事業報告
+
+株式会社サンプル
+
+<!-- 挨拶から始める。時間は30分。 -->
+
+---
+
+<!-- layout: Title and Content -->
+
+## 売上サマリー
+
+- 売上高: **120億円**（前年比 +15%）
+- 営業利益: **18億円**（前年比 +22%）
+- 新規顧客数: *350社*
+
+<!-- 売上高の内訳を聞かれたらP5を参照 -->
+
+---
+
+## 主要施策の成果
+
+1. 新製品Aのローンチ
+   - 発売3ヶ月で目標の120%達成
+2. 海外展開の加速
+   - アジア3カ国に新規進出
+3. DX推進
+   - 社内業務の~~手作業~~自動化率 80%達成
+
+---
+
+<!-- _layout: Two Content -->
+
+## 今後の展望
+
+- 2025年度 売上目標: **150億円**
+- 重点投資領域:
+  - AI活用
+  - サステナビリティ
+
+![w:400](./images/roadmap.png)
+
+---
+
+<!-- _layout: Title Slide -->
+
+# ご清聴ありがとうございました
+
+お問い合わせ: [info@example.com](mailto:info@example.com)`;
+
+    const result = parseMarkdown(input);
+
+    // Front matter
+    expect(result.frontMatter.template).toBe("./templates/company.pptx");
+    expect(result.frontMatter.title).toBe("2024年度 事業報告");
+    expect(result.frontMatter.author).toBe("山田太郎");
+
+    // 5 slides
+    expect(result.slides).toHaveLength(5);
+
+    // Slide 1: Title Slide (spot)
+    expect(result.slides[0].layout).toBe("Title Slide");
+    expect(result.slides[0].content[0]).toEqual({
+      type: "heading",
+      level: 1,
+      runs: [{ text: "2024年度 事業報告" }],
+    });
+    expect(result.slides[0].notes).toContain("挨拶から始める。時間は30分。");
+
+    // Slide 2: Title and Content (local)
+    expect(result.slides[1].layout).toBe("Title and Content");
+    expect(result.slides[1].content[0]).toEqual({
+      type: "heading",
+      level: 2,
+      runs: [{ text: "売上サマリー" }],
+    });
+    expect(result.slides[1].content[1].type).toBe("list");
+
+    // Slide 3: Title and Content (inherited)
+    expect(result.slides[2].layout).toBe("Title and Content");
+
+    // Slide 4: Two Content (spot)
+    expect(result.slides[3].layout).toBe("Two Content");
+    // Has an image
+    const imgElement = result.slides[3].content.find((e) => e.type === "image");
+    expect(imgElement).toBeDefined();
+    if (imgElement?.type === "image") {
+      expect(imgElement.image.src).toBe("./images/roadmap.png");
+      expect(imgElement.image.width).toBe(400);
+    }
+
+    // Slide 5: Title Slide (spot), layout reverts to Title and Content
+    expect(result.slides[4].layout).toBe("Title Slide");
+
+    // Slide 5 has a hyperlink
+    const lastParagraph = result.slides[4].content.find(
+      (e) => e.type === "paragraph",
+    );
+    expect(lastParagraph).toBeDefined();
+    if (lastParagraph?.type === "paragraph") {
+      const linkRun = lastParagraph.runs.find((r) => r.link);
+      expect(linkRun).toBeDefined();
+      expect(linkRun?.link).toBe("mailto:info@example.com");
+    }
+  });
+
+  it("should handle empty input", () => {
+    const result = parseMarkdown("");
+
+    expect(result.frontMatter).toEqual({});
+    expect(result.slides).toHaveLength(1);
+    expect(result.slides[0].content).toHaveLength(0);
+  });
+
+  it("should handle front matter only", () => {
+    const input = `---
+template: ./t.pptx
+---`;
+
+    const result = parseMarkdown(input);
+
+    expect(result.frontMatter.template).toBe("./t.pptx");
+    expect(result.slides).toHaveLength(1);
+  });
+});

--- a/src/__tests__/slide-splitter.test.ts
+++ b/src/__tests__/slide-splitter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import MarkdownIt from "markdown-it";
+import { splitTokensIntoSlides } from "../slide-splitter.js";
+
+const md = new MarkdownIt({ html: true });
+
+describe("splitTokensIntoSlides", () => {
+  it("should split on --- (hr tokens)", () => {
+    const tokens = md.parse(
+      "# Slide 1\n\nBody 1\n\n---\n\n# Slide 2\n\nBody 2",
+      {},
+    );
+    const slides = splitTokensIntoSlides(tokens);
+
+    expect(slides).toHaveLength(2);
+    expect(slides[0].some((t) => t.type === "heading_open")).toBe(true);
+    expect(slides[1].some((t) => t.type === "heading_open")).toBe(true);
+  });
+
+  it("should produce single slide when no delimiter exists", () => {
+    const tokens = md.parse("# Title\n\nBody", {});
+    const slides = splitTokensIntoSlides(tokens);
+
+    expect(slides).toHaveLength(1);
+  });
+
+  it("should handle multiple --- delimiters", () => {
+    const tokens = md.parse("Slide 1\n\n---\n\nSlide 2\n\n---\n\nSlide 3", {});
+    const slides = splitTokensIntoSlides(tokens);
+
+    expect(slides).toHaveLength(3);
+  });
+
+  it("should handle empty slides between delimiters", () => {
+    const tokens = md.parse("---\n\n---", {});
+    const slides = splitTokensIntoSlides(tokens);
+
+    expect(slides).toHaveLength(3);
+  });
+
+  it("should apply headingDivider with single number", () => {
+    const tokens = md.parse("## Slide 1\n\nBody 1\n\n## Slide 2\n\nBody 2", {});
+    const slides = splitTokensIntoSlides(tokens, 2);
+
+    expect(slides).toHaveLength(2);
+  });
+
+  it("should split on heading levels <= headingDivider", () => {
+    const tokens = md.parse(
+      "# Section\n\n## Slide 1\n\nBody\n\n## Slide 2\n\nBody",
+      {},
+    );
+    const slides = splitTokensIntoSlides(tokens, 2);
+
+    expect(slides).toHaveLength(3);
+  });
+
+  it("should not split on heading levels > headingDivider", () => {
+    const tokens = md.parse("### Sub 1\n\nBody\n\n### Sub 2\n\nBody", {});
+    const slides = splitTokensIntoSlides(tokens, 2);
+
+    expect(slides).toHaveLength(1);
+  });
+
+  it("should apply headingDivider as array", () => {
+    const tokens = md.parse("# Section\n\nBody\n\n### Sub\n\nBody", {});
+    const slides = splitTokensIntoSlides(tokens, [1, 3]);
+
+    expect(slides).toHaveLength(2);
+  });
+
+  it("should combine --- split and headingDivider", () => {
+    const tokens = md.parse(
+      "## Slide 1\n\nBody\n\n---\n\n## Slide 2\n\nBody\n\n## Slide 3\n\nBody",
+      {},
+    );
+    const slides = splitTokensIntoSlides(tokens, 2);
+
+    expect(slides).toHaveLength(3);
+  });
+});

--- a/src/__tests__/token-converter.test.ts
+++ b/src/__tests__/token-converter.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "vitest";
+import MarkdownIt from "markdown-it";
+import { convertTokensToSlide } from "../token-converter.js";
+
+const md = new MarkdownIt({ html: true });
+md.enable("strikethrough");
+
+function tokensFor(input: string) {
+  return md.parse(input, {});
+}
+
+describe("convertTokensToSlide", () => {
+  describe("headings", () => {
+    it("should extract h1 heading", () => {
+      const slide = convertTokensToSlide(tokensFor("# Hello World"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "heading",
+        level: 1,
+        runs: [{ text: "Hello World" }],
+      });
+    });
+
+    it("should extract h2 heading", () => {
+      const slide = convertTokensToSlide(tokensFor("## Sub Title"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "heading",
+        level: 2,
+        runs: [{ text: "Sub Title" }],
+      });
+    });
+
+    it("should handle heading with inline formatting", () => {
+      const slide = convertTokensToSlide(tokensFor("# **Bold** Title"));
+      expect(slide.content[0]).toEqual({
+        type: "heading",
+        level: 1,
+        runs: [{ text: "Bold", bold: true }, { text: " Title" }],
+      });
+    });
+  });
+
+  describe("paragraphs", () => {
+    it("should extract plain paragraph", () => {
+      const slide = convertTokensToSlide(tokensFor("Hello world"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "Hello world" }],
+      });
+    });
+
+    it("should handle bold text", () => {
+      const slide = convertTokensToSlide(tokensFor("**bold text**"));
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "bold text", bold: true }],
+      });
+    });
+
+    it("should handle italic text", () => {
+      const slide = convertTokensToSlide(tokensFor("*italic text*"));
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "italic text", italic: true }],
+      });
+    });
+
+    it("should handle inline code", () => {
+      const slide = convertTokensToSlide(tokensFor("`code`"));
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "code", code: true }],
+      });
+    });
+
+    it("should handle strikethrough text", () => {
+      const slide = convertTokensToSlide(tokensFor("~~deleted~~"));
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "deleted", strikethrough: true }],
+      });
+    });
+
+    it("should handle hyperlinks", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("[click here](https://example.com)"),
+      );
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "click here", link: "https://example.com" }],
+      });
+    });
+
+    it("should handle mixed formatting", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("Normal **bold** and *italic* text"),
+      );
+      const paragraph = slide.content[0];
+      expect(paragraph.type).toBe("paragraph");
+      if (paragraph.type === "paragraph") {
+        expect(paragraph.runs).toEqual([
+          { text: "Normal " },
+          { text: "bold", bold: true },
+          { text: " and " },
+          { text: "italic", italic: true },
+          { text: " text" },
+        ]);
+      }
+    });
+
+    it("should handle hardbreak (trailing two spaces)", () => {
+      const slide = convertTokensToSlide(tokensFor("line1  \nline2"));
+      expect(slide.content[0]).toEqual({
+        type: "paragraph",
+        runs: [{ text: "line1" }, { text: "\n" }, { text: "line2" }],
+      });
+    });
+  });
+
+  describe("lists", () => {
+    it("should extract unordered list", () => {
+      const slide = convertTokensToSlide(tokensFor("- Item 1\n- Item 2"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "list",
+        items: [
+          { runs: [{ text: "Item 1" }], level: 0, ordered: false },
+          { runs: [{ text: "Item 2" }], level: 0, ordered: false },
+        ],
+      });
+    });
+
+    it("should extract ordered list", () => {
+      const slide = convertTokensToSlide(tokensFor("1. First\n2. Second"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "list",
+        items: [
+          { runs: [{ text: "First" }], level: 0, ordered: true },
+          { runs: [{ text: "Second" }], level: 0, ordered: true },
+        ],
+      });
+    });
+
+    it("should handle nested lists", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("- Parent\n  - Child\n    - Grandchild"),
+      );
+      expect(slide.content).toHaveLength(1);
+      if (slide.content[0].type === "list") {
+        expect(slide.content[0].items).toHaveLength(3);
+        expect(slide.content[0].items[0].level).toBe(0);
+        expect(slide.content[0].items[1].level).toBe(1);
+        expect(slide.content[0].items[2].level).toBe(2);
+      }
+    });
+
+    it("should handle list items with formatting", () => {
+      const slide = convertTokensToSlide(tokensFor("- **Bold** item"));
+      if (slide.content[0].type === "list") {
+        expect(slide.content[0].items[0].runs).toEqual([
+          { text: "Bold", bold: true },
+          { text: " item" },
+        ]);
+      }
+    });
+  });
+
+  describe("images", () => {
+    it("should extract image", () => {
+      const slide = convertTokensToSlide(tokensFor("![alt text](./image.png)"));
+      expect(slide.content).toHaveLength(1);
+      expect(slide.content[0]).toEqual({
+        type: "image",
+        image: { src: "./image.png", alt: "alt text" },
+      });
+    });
+
+    it("should parse width from alt text", () => {
+      const slide = convertTokensToSlide(tokensFor("![w:400](./img.png)"));
+      expect(slide.content[0]).toEqual({
+        type: "image",
+        image: { src: "./img.png", width: 400 },
+      });
+    });
+
+    it("should parse height from alt text", () => {
+      const slide = convertTokensToSlide(tokensFor("![h:300](./img.png)"));
+      expect(slide.content[0]).toEqual({
+        type: "image",
+        image: { src: "./img.png", height: 300 },
+      });
+    });
+
+    it("should parse both width and height", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("![w:400 h:300](./img.png)"),
+      );
+      expect(slide.content[0]).toEqual({
+        type: "image",
+        image: { src: "./img.png", width: 400, height: 300 },
+      });
+    });
+
+    it("should parse width:px and height:px format", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("![width:400px height:300px](./img.png)"),
+      );
+      expect(slide.content[0]).toEqual({
+        type: "image",
+        image: { src: "./img.png", width: 400, height: 300 },
+      });
+    });
+  });
+
+  describe("directives", () => {
+    it("should extract local directive from HTML comment", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("<!-- layout: Title Slide -->"),
+      );
+      expect(slide.directives).toHaveLength(1);
+      expect(slide.directives[0]).toEqual({
+        key: "layout",
+        value: "Title Slide",
+        scope: "local",
+      });
+    });
+
+    it("should extract spot directive", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("<!-- _layout: Section -->"),
+      );
+      expect(slide.directives).toHaveLength(1);
+      expect(slide.directives[0]).toEqual({
+        key: "layout",
+        value: "Section",
+        scope: "spot",
+      });
+    });
+  });
+
+  describe("presenter notes", () => {
+    it("should extract non-directive comment as presenter note", () => {
+      const slide = convertTokensToSlide(
+        tokensFor("<!-- Remember to explain this -->"),
+      );
+      expect(slide.notes).toHaveLength(1);
+      expect(slide.notes[0]).toBe("Remember to explain this");
+    });
+
+    it("should separate directives and notes", () => {
+      const input =
+        "<!-- layout: Title -->\n\n# Title\n\n<!-- This is a note -->";
+      const slide = convertTokensToSlide(tokensFor(input));
+      expect(slide.directives).toHaveLength(1);
+      expect(slide.notes).toHaveLength(1);
+      expect(slide.notes[0]).toBe("This is a note");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("should handle heading + paragraph + list", () => {
+      const input = "## Title\n\nSome text\n\n- Item 1\n- Item 2";
+      const slide = convertTokensToSlide(tokensFor(input));
+
+      expect(slide.content).toHaveLength(3);
+      expect(slide.content[0].type).toBe("heading");
+      expect(slide.content[1].type).toBe("paragraph");
+      expect(slide.content[2].type).toBe("list");
+    });
+  });
+});

--- a/src/directives.ts
+++ b/src/directives.ts
@@ -1,0 +1,32 @@
+import type { Directive } from "./types.js";
+
+export const DIRECTIVE_KEYS = [
+  "layout",
+  "paginate",
+  "header",
+  "footer",
+] as const;
+
+export type DirectiveKey = (typeof DIRECTIVE_KEYS)[number];
+
+const DIRECTIVE_RE = new RegExp(
+  `^\\s*(_?)(${DIRECTIVE_KEYS.join("|")})\\s*:\\s*(.+?)\\s*$`,
+);
+
+export function parseDirective(comment: string): Directive | null {
+  const match = DIRECTIVE_RE.exec(comment);
+  if (!match) return null;
+
+  return {
+    key: match[2],
+    value: match[3],
+    scope: match[1] === "_" ? "spot" : "local",
+  };
+}
+
+const COMMENT_RE = /^<!--\s*([\s\S]*?)\s*-->$/;
+
+export function extractCommentContent(html: string): string | null {
+  const match = COMMENT_RE.exec(html.trim());
+  return match ? match[1] : null;
+}

--- a/src/front-matter.ts
+++ b/src/front-matter.ts
@@ -1,0 +1,80 @@
+import type { FrontMatter } from "./types.js";
+
+export interface ExtractFrontMatterResult {
+  frontMatter: FrontMatter;
+  body: string;
+}
+
+const FRONT_MATTER_RE =
+  /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)|^---\r?\n---(?:\r?\n|$)/;
+
+function parseValue(raw: string): string | number | number[] {
+  const trimmed = raw.trim();
+
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    const inner = trimmed.slice(1, -1);
+    const nums = inner
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map(Number)
+      .filter(
+        (n) => Number.isFinite(n) && Number.isInteger(n) && n >= 1 && n <= 6,
+      );
+    return nums.length > 0 ? nums : trimmed;
+  }
+
+  const num = Number(trimmed);
+  if (Number.isFinite(num) && Number.isInteger(num) && num >= 1 && num <= 6) {
+    return num;
+  }
+
+  return trimmed;
+}
+
+export function extractFrontMatter(input: string): ExtractFrontMatterResult {
+  const match = FRONT_MATTER_RE.exec(input);
+
+  if (!match) {
+    return { frontMatter: {}, body: input };
+  }
+
+  const yamlBlock = match[1] ?? "";
+  const body = input.slice(match[0].length);
+  const frontMatter: FrontMatter = {};
+
+  for (const line of yamlBlock.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+
+    const colonIndex = trimmed.indexOf(":");
+    if (colonIndex === -1) continue;
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+
+    switch (key) {
+      case "template":
+        frontMatter.template = String(value);
+        break;
+      case "layout":
+        frontMatter.layout = String(value);
+        break;
+      case "headingDivider": {
+        const parsed = parseValue(value);
+        if (typeof parsed === "number" || Array.isArray(parsed)) {
+          frontMatter.headingDivider = parsed;
+        }
+        break;
+      }
+      case "author":
+        frontMatter.author = String(value);
+        break;
+      case "title":
+        frontMatter.title = String(value);
+        break;
+    }
+  }
+
+  return { frontMatter, body };
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect } from "vitest";
-import * as mod from "./index";
+import { parseMarkdown } from "./index.js";
 
 describe("md-pptx", () => {
-  it("should export the module", () => {
-    expect(mod).toBeDefined();
+  it("should export parseMarkdown", () => {
+    expect(parseMarkdown).toBeDefined();
+    expect(typeof parseMarkdown).toBe("function");
+  });
+
+  it("should parse markdown and return result", () => {
+    const result = parseMarkdown("# Hello");
+    expect(result.frontMatter).toBeDefined();
+    expect(result.slides).toBeDefined();
+    expect(result.slides).toHaveLength(1);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,16 @@
-export {};
+export { parseMarkdown } from "./parser.js";
+export type {
+  ParseResult,
+  FrontMatter,
+  SlideData,
+  ContentElement,
+  HeadingElement,
+  ParagraphElement,
+  ListElement,
+  ImageElement,
+  ListItem,
+  TextRun,
+  ImageData,
+  Directive,
+  DirectiveScope,
+} from "./types.js";

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,0 +1,45 @@
+import MarkdownIt from "markdown-it";
+import type { ParseResult, SlideData, FrontMatter } from "./types.js";
+import { extractFrontMatter } from "./front-matter.js";
+import { splitTokensIntoSlides } from "./slide-splitter.js";
+import { convertTokensToSlide } from "./token-converter.js";
+
+const md = new MarkdownIt({ html: true });
+md.enable("strikethrough");
+
+function resolveDirectives(
+  slides: SlideData[],
+  frontMatter: FrontMatter,
+): void {
+  let currentLayout = frontMatter.layout;
+
+  for (const slide of slides) {
+    let spotLayout: string | undefined;
+
+    for (const directive of slide.directives) {
+      if (directive.key === "layout") {
+        if (directive.scope === "local") {
+          currentLayout = directive.value;
+        } else {
+          spotLayout = directive.value;
+        }
+      }
+    }
+
+    slide.layout = spotLayout ?? currentLayout;
+  }
+}
+
+export function parseMarkdown(input: string): ParseResult {
+  const { frontMatter, body } = extractFrontMatter(input);
+  const tokens = md.parse(body, {});
+  const slideTokenGroups = splitTokensIntoSlides(
+    tokens,
+    frontMatter.headingDivider,
+  );
+  const slides = slideTokenGroups.map(convertTokensToSlide);
+
+  resolveDirectives(slides, frontMatter);
+
+  return { frontMatter, slides };
+}

--- a/src/slide-splitter.ts
+++ b/src/slide-splitter.ts
@@ -1,0 +1,60 @@
+import type Token from "markdown-it/lib/token.mjs";
+
+function getHeadingLevel(token: Token): number | null {
+  if (token.type !== "heading_open") return null;
+  const match = /^h(\d)$/.exec(token.tag);
+  return match ? Number(match[1]) : null;
+}
+
+function shouldSplitOnHeading(
+  level: number,
+  headingDivider: number | number[],
+): boolean {
+  if (Array.isArray(headingDivider)) {
+    return headingDivider.includes(level);
+  }
+  return level <= headingDivider;
+}
+
+export function splitTokensIntoSlides(
+  tokens: Token[],
+  headingDivider?: number | number[],
+): Token[][] {
+  // Phase 1: Split on hr tokens (---)
+  const groups: Token[][] = [[]];
+
+  for (const token of tokens) {
+    if (token.type === "hr") {
+      groups.push([]);
+    } else {
+      groups[groups.length - 1].push(token);
+    }
+  }
+
+  // Phase 2: Apply headingDivider if specified
+  if (headingDivider === undefined) {
+    return groups;
+  }
+
+  const result: Token[][] = [];
+
+  for (const group of groups) {
+    let current: Token[] = [];
+
+    for (const token of group) {
+      const level = getHeadingLevel(token);
+      if (level !== null && shouldSplitOnHeading(level, headingDivider)) {
+        if (current.length > 0) {
+          result.push(current);
+        }
+        current = [token];
+      } else {
+        current.push(token);
+      }
+    }
+
+    result.push(current);
+  }
+
+  return result;
+}

--- a/src/token-converter.ts
+++ b/src/token-converter.ts
@@ -1,0 +1,251 @@
+import type Token from "markdown-it/lib/token.mjs";
+import type {
+  SlideData,
+  ContentElement,
+  TextRun,
+  ListItem,
+  ImageData,
+} from "./types.js";
+import { parseDirective, extractCommentContent } from "./directives.js";
+
+// === Image alt text size parsing ===
+
+const SIZE_W_RE = /(?:^|\s)(?:w(?:idth)?):(\d+)(?:px)?/;
+const SIZE_H_RE = /(?:^|\s)(?:h(?:eight)?):(\d+)(?:px)?/;
+
+function parseImageAlt(alt: string): {
+  alt?: string;
+  width?: number;
+  height?: number;
+} {
+  const widthMatch = SIZE_W_RE.exec(alt);
+  const heightMatch = SIZE_H_RE.exec(alt);
+
+  const cleanAlt = alt
+    .replace(/(?:^|\s)(?:w(?:idth)?):(\d+)(?:px)?/g, "")
+    .replace(/(?:^|\s)(?:h(?:eight)?):(\d+)(?:px)?/g, "")
+    .trim();
+
+  return {
+    alt: cleanAlt || undefined,
+    width: widthMatch ? Number(widthMatch[1]) : undefined,
+    height: heightMatch ? Number(heightMatch[1]) : undefined,
+  };
+}
+
+// === Inline token → TextRun[] conversion ===
+
+interface FormatState {
+  bold: boolean;
+  italic: boolean;
+  strikethrough: boolean;
+  link?: string;
+}
+
+function convertInlineTokens(tokens: Token[]): TextRun[] {
+  const runs: TextRun[] = [];
+  const state: FormatState = {
+    bold: false,
+    italic: false,
+    strikethrough: false,
+  };
+
+  for (const token of tokens) {
+    switch (token.type) {
+      case "strong_open":
+        state.bold = true;
+        break;
+      case "strong_close":
+        state.bold = false;
+        break;
+      case "em_open":
+        state.italic = true;
+        break;
+      case "em_close":
+        state.italic = false;
+        break;
+      case "s_open":
+        state.strikethrough = true;
+        break;
+      case "s_close":
+        state.strikethrough = false;
+        break;
+      case "link_open": {
+        const href = token.attrGet("href");
+        if (href) state.link = href;
+        break;
+      }
+      case "link_close":
+        state.link = undefined;
+        break;
+      case "code_inline":
+        runs.push({ text: token.content, code: true });
+        break;
+      case "text":
+        if (token.content !== "") {
+          runs.push(buildRun(token.content, state));
+        }
+        break;
+      case "softbreak":
+      case "hardbreak":
+        runs.push(buildRun("\n", state));
+        break;
+    }
+  }
+
+  return runs;
+}
+
+function buildRun(text: string, state: FormatState): TextRun {
+  const run: TextRun = { text };
+  if (state.bold) run.bold = true;
+  if (state.italic) run.italic = true;
+  if (state.strikethrough) run.strikethrough = true;
+  if (state.link) run.link = state.link;
+  return run;
+}
+
+// === Image extraction from inline tokens ===
+
+function extractImage(tokens: Token[]): ImageData | null {
+  const imgToken = tokens.find((t) => t.type === "image");
+  if (!imgToken) return null;
+
+  const src = imgToken.attrGet("src");
+  if (!src) return null;
+
+  const rawAlt = imgToken.children
+    ? imgToken.children
+        .filter((c) => c.type === "text")
+        .map((c) => c.content)
+        .join("")
+    : "";
+
+  const { alt, width, height } = parseImageAlt(rawAlt);
+
+  return { src, alt, width, height };
+}
+
+function isImageOnlyParagraph(inlineToken: Token): boolean {
+  if (!inlineToken.children) return false;
+  const nonEmpty = inlineToken.children.filter(
+    (t) => !(t.type === "text" && t.content.trim() === ""),
+  );
+  return nonEmpty.length === 1 && nonEmpty[0].type === "image";
+}
+
+// === Main converter ===
+
+export function convertTokensToSlide(tokens: Token[]): SlideData {
+  const content: ContentElement[] = [];
+  const notes: string[] = [];
+  const directives: SlideData["directives"] = [];
+
+  let i = 0;
+  let listItems: ListItem[] = [];
+  const listTypeStack: boolean[] = []; // stack of ordered flags
+
+  while (i < tokens.length) {
+    const token = tokens[i];
+
+    // HTML comments (directives or presenter notes)
+    if (token.type === "html_block") {
+      const commentContent = extractCommentContent(token.content);
+      if (commentContent !== null) {
+        const directive = parseDirective(commentContent);
+        if (directive) {
+          directives.push(directive);
+        } else {
+          notes.push(commentContent);
+        }
+      }
+      i++;
+      continue;
+    }
+
+    // Headings
+    if (token.type === "heading_open") {
+      const levelMatch = /^h(\d)$/.exec(token.tag);
+      const level = levelMatch ? Number(levelMatch[1]) : 1;
+      const inlineToken = tokens[i + 1];
+      const runs = inlineToken?.children
+        ? convertInlineTokens(inlineToken.children)
+        : [];
+
+      content.push({
+        type: "heading",
+        level: level as 1 | 2 | 3 | 4 | 5 | 6,
+        runs,
+      });
+
+      i += 3; // heading_open, inline, heading_close
+      continue;
+    }
+
+    // Lists - open
+    if (
+      token.type === "bullet_list_open" ||
+      token.type === "ordered_list_open"
+    ) {
+      listTypeStack.push(token.type === "ordered_list_open");
+      i++;
+      continue;
+    }
+
+    // Lists - close
+    if (
+      token.type === "bullet_list_close" ||
+      token.type === "ordered_list_close"
+    ) {
+      listTypeStack.pop();
+      if (listTypeStack.length === 0 && listItems.length > 0) {
+        content.push({ type: "list", items: [...listItems] });
+        listItems = [];
+      }
+      i++;
+      continue;
+    }
+
+    // List item - skip open/close markers
+    if (token.type === "list_item_open" || token.type === "list_item_close") {
+      i++;
+      continue;
+    }
+
+    // Paragraphs (also handles paragraphs inside list items)
+    if (token.type === "paragraph_open") {
+      const inlineToken = tokens[i + 1];
+
+      if (listTypeStack.length > 0) {
+        // Inside a list - add as list item
+        if (inlineToken?.children) {
+          const runs = convertInlineTokens(inlineToken.children);
+          if (runs.length > 0) {
+            listItems.push({
+              runs,
+              level: listTypeStack.length - 1,
+              ordered: listTypeStack[listTypeStack.length - 1],
+            });
+          }
+        }
+      } else if (inlineToken && isImageOnlyParagraph(inlineToken)) {
+        const image = extractImage(inlineToken.children!);
+        if (image) {
+          content.push({ type: "image", image });
+        }
+      } else if (inlineToken?.children) {
+        const runs = convertInlineTokens(inlineToken.children);
+        if (runs.length > 0) {
+          content.push({ type: "paragraph", runs });
+        }
+      }
+
+      i += 3; // paragraph_open, inline, paragraph_close
+      continue;
+    }
+
+    i++;
+  }
+
+  return { content, notes, directives };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,90 @@
+// === Front Matter ===
+
+export interface FrontMatter {
+  template?: string;
+  layout?: string;
+  headingDivider?: number | number[];
+  author?: string;
+  title?: string;
+}
+
+// === Directives ===
+
+export type DirectiveScope = "local" | "spot";
+
+export interface Directive {
+  key: string;
+  value: string;
+  scope: DirectiveScope;
+}
+
+// === Text Formatting ===
+
+export interface TextRun {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  code?: boolean;
+  strikethrough?: boolean;
+  link?: string;
+}
+
+// === Image ===
+
+export interface ImageData {
+  src: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+// === Content Elements ===
+
+export interface HeadingElement {
+  type: "heading";
+  level: 1 | 2 | 3 | 4 | 5 | 6;
+  runs: TextRun[];
+}
+
+export interface ParagraphElement {
+  type: "paragraph";
+  runs: TextRun[];
+}
+
+export interface ListItem {
+  runs: TextRun[];
+  level: number;
+  ordered: boolean;
+}
+
+export interface ListElement {
+  type: "list";
+  items: ListItem[];
+}
+
+export interface ImageElement {
+  type: "image";
+  image: ImageData;
+}
+
+export type ContentElement =
+  | HeadingElement
+  | ParagraphElement
+  | ListElement
+  | ImageElement;
+
+// === Slide ===
+
+export interface SlideData {
+  layout?: string;
+  content: ContentElement[];
+  notes: string[];
+  directives: Directive[];
+}
+
+// === Parse Result ===
+
+export interface ParseResult {
+  frontMatter: FrontMatter;
+  slides: SlideData[];
+}


### PR DESCRIPTION
close #8

## 概要

Marp互換のMarkdown記法をスライド単位のデータ構造に変換するパーサーを実装しました。

## 変更内容

- `src/types.ts` — 型定義（FrontMatter, Directive, TextRun, SlideData, ParseResult 等）
- `src/front-matter.ts` — YAMLフロントマターの抽出・パース（headingDivider のバリデーション付き）
- `src/directives.ts` — HTMLコメントディレクティブの解析（local/spot スコープ対応）
- `src/slide-splitter.ts` — `---` 区切り + headingDivider によるスライド分割
- `src/token-converter.ts` — markdown-itトークンからSlideDataへの変換（見出し、段落、リスト、画像、書式、プレゼンターノート）
- `src/parser.ts` — `parseMarkdown()` エントリポイント + ディレクティブ解決ロジック
- `src/index.ts` — 公開API re-export
- `src/__tests__/` — 各モジュールの単体テスト + 統合テスト（71テストケース）

## 対応した仕様

- フロントマター（template, layout, headingDivider, author, title）
- スライド区切り（`---` + headingDivider 自動分割）
- ディレクティブ（layout, paginate, header, footer / local・spot スコープ）
- テキスト書式（bold, italic, code, strikethrough, hyperlink, hardbreak）
- 画像サイズ指定（`w:`, `h:`, `width:`, `height:`）
- プレゼンターノート（非ディレクティブHTMLコメント）

## テスト計画

- [x] `npm run test` — 71テスト全通過
- [x] `npm run typecheck` — 型チェック通過
- [x] `npm run lint` — ESLint通過
- [x] `npm run format:check` — Prettier通過
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)