### PR TITLE
feat: テンプレートPPTX読み込みとプレースホルダマッピング

### DIFF
--- a/src/__tests__/placeholder-mapper.test.ts
+++ b/src/__tests__/placeholder-mapper.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from "vitest";
+import {
+  mapSlideToPlaceholders,
+  mapPresentation,
+} from "../placeholder-mapper.js";
+import type {
+  SlideData,
+  LayoutInfo,
+  ContentElement,
+  HeadingElement,
+  ParagraphElement,
+  ListElement,
+  ImageElement,
+  TemplateInfo,
+  ParseResult,
+} from "../types.js";
+
+// === ヘルパー ===
+
+function heading(level: 1 | 2 | 3 | 4 | 5 | 6, text: string): HeadingElement {
+  return { type: "heading", level, runs: [{ text }] };
+}
+
+function paragraph(text: string): ParagraphElement {
+  return { type: "paragraph", runs: [{ text }] };
+}
+
+function list(items: string[]): ListElement {
+  return {
+    type: "list",
+    items: items.map((text) => ({
+      runs: [{ text }],
+      level: 0,
+      ordered: false,
+    })),
+  };
+}
+
+function image(src: string): ImageElement {
+  return { type: "image", image: { src } };
+}
+
+function slide(content: ContentElement[], layout?: string): SlideData {
+  return { content, notes: [], directives: [], layout };
+}
+
+const TITLE_AND_CONTENT_LAYOUT: LayoutInfo = {
+  name: "Title and Content",
+  placeholders: [
+    { idx: 0, type: "title", name: "Title 1" },
+    { idx: 1, type: "body", name: "Content Placeholder 2" },
+  ],
+};
+
+const TITLE_ONLY_LAYOUT: LayoutInfo = {
+  name: "Title Only",
+  placeholders: [{ idx: 0, type: "title", name: "Title 1" }],
+};
+
+const PICTURE_LAYOUT: LayoutInfo = {
+  name: "Picture with Caption",
+  placeholders: [
+    { idx: 0, type: "title", name: "Title 1" },
+    { idx: 1, type: "body", name: "Text Placeholder 2" },
+    { idx: 2, type: "picture", name: "Picture Placeholder 3" },
+  ],
+};
+
+const SUBTITLE_ONLY_LAYOUT: LayoutInfo = {
+  name: "Subtitle Only",
+  placeholders: [
+    { idx: 0, type: "subtitle", name: "Subtitle 1" },
+    { idx: 1, type: "body", name: "Body 1" },
+  ],
+};
+
+const BLANK_LAYOUT: LayoutInfo = {
+  name: "Blank",
+  placeholders: [],
+};
+
+// === テスト ===
+
+describe("mapSlideToPlaceholders", () => {
+  describe("基本マッピング", () => {
+    it("h1見出し → title、本文 → body にマッピングする", () => {
+      const s = slide([heading(1, "タイトル"), paragraph("本文テキスト")]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      expect(result.layoutName).toBe("Title and Content");
+      expect(result.fallbackToBlank).toBe(false);
+      expect(result.assignments).toHaveLength(2);
+
+      const titleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "title",
+      );
+      expect(titleAssignment).toBeDefined();
+      expect(titleAssignment!.placeholderIdx).toBe(0);
+      expect(titleAssignment!.content).toHaveLength(1);
+      expect(titleAssignment!.content[0].type).toBe("heading");
+
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment).toBeDefined();
+      expect(bodyAssignment!.placeholderIdx).toBe(1);
+      expect(bodyAssignment!.content).toHaveLength(1);
+      expect(bodyAssignment!.content[0].type).toBe("paragraph");
+    });
+
+    it("h2見出しもtitleプレースホルダにマッピングする", () => {
+      const s = slide([heading(2, "サブタイトル"), paragraph("本文")]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      const titleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "title",
+      );
+      expect(titleAssignment).toBeDefined();
+      expect(titleAssignment!.content[0]).toEqual(heading(2, "サブタイトル"));
+    });
+
+    it("h3以下の見出しはbodyにマッピングする", () => {
+      const s = slide([heading(3, "小見出し"), paragraph("本文")]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      expect(result.assignments).toHaveLength(1);
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment).toBeDefined();
+      expect(bodyAssignment!.content).toHaveLength(2);
+    });
+
+    it("リストをbodyにマッピングする", () => {
+      const s = slide([heading(1, "タイトル"), list(["項目1", "項目2"])]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment).toBeDefined();
+      expect(bodyAssignment!.content).toHaveLength(1);
+      expect(bodyAssignment!.content[0].type).toBe("list");
+    });
+
+    it("最初のh1/h2のみtitleに割り当て、2番目以降はbodyに入る", () => {
+      const s = slide([
+        heading(1, "最初の見出し"),
+        heading(2, "2番目の見出し"),
+        paragraph("本文"),
+      ]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      const titleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "title",
+      );
+      expect(titleAssignment!.content).toHaveLength(1);
+
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment!.content).toHaveLength(2);
+    });
+  });
+
+  describe("subtitleマッピング", () => {
+    it("titleがなくsubtitleがあるレイアウトではsubtitleにフォールバックする", () => {
+      const s = slide([heading(1, "タイトル"), paragraph("本文")]);
+      const result = mapSlideToPlaceholders(s, SUBTITLE_ONLY_LAYOUT);
+
+      const subtitleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "subtitle",
+      );
+      expect(subtitleAssignment).toBeDefined();
+      expect(subtitleAssignment!.placeholderIdx).toBe(0);
+      expect(subtitleAssignment!.content).toHaveLength(1);
+      expect(subtitleAssignment!.content[0].type).toBe("heading");
+
+      expect(result.unmappedContent).toHaveLength(0);
+    });
+
+    it("titleとsubtitle両方あるレイアウトではtitleが優先される", () => {
+      const titleAndSubtitleLayout: LayoutInfo = {
+        name: "Title and Subtitle",
+        placeholders: [
+          { idx: 0, type: "title", name: "Title 1" },
+          { idx: 1, type: "subtitle", name: "Subtitle 1" },
+        ],
+      };
+      const s = slide([heading(1, "タイトル")]);
+      const result = mapSlideToPlaceholders(s, titleAndSubtitleLayout);
+
+      const titleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "title",
+      );
+      expect(titleAssignment).toBeDefined();
+      expect(titleAssignment!.content).toHaveLength(1);
+
+      const subtitleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "subtitle",
+      );
+      expect(subtitleAssignment).toBeUndefined();
+    });
+  });
+
+  describe("画像マッピング", () => {
+    it("pictureプレースホルダがあれば画像をそこにマッピングする", () => {
+      const s = slide([
+        heading(1, "タイトル"),
+        image("photo.png"),
+        paragraph("キャプション"),
+      ]);
+      const result = mapSlideToPlaceholders(s, PICTURE_LAYOUT);
+
+      const picAssignment = result.assignments.find(
+        (a) => a.placeholderType === "picture",
+      );
+      expect(picAssignment).toBeDefined();
+      expect(picAssignment!.placeholderIdx).toBe(2);
+      expect(picAssignment!.content).toHaveLength(1);
+      expect(picAssignment!.content[0].type).toBe("image");
+    });
+
+    it("pictureプレースホルダがない場合、画像をbodyにマッピングする", () => {
+      const s = slide([heading(1, "タイトル"), image("photo.png")]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment).toBeDefined();
+      expect(bodyAssignment!.content).toHaveLength(1);
+      expect(bodyAssignment!.content[0].type).toBe("image");
+    });
+
+    it("pictureもbodyもない場合、画像はunmappedになる", () => {
+      const s = slide([image("photo.png")]);
+      const result = mapSlideToPlaceholders(s, TITLE_ONLY_LAYOUT);
+
+      expect(result.unmappedContent).toHaveLength(1);
+      expect(result.unmappedContent[0].type).toBe("image");
+    });
+  });
+
+  describe("フォールバック", () => {
+    it("プレースホルダがないレイアウトでBlankにフォールバックする", () => {
+      const s = slide([heading(1, "タイトル"), paragraph("本文")]);
+      const result = mapSlideToPlaceholders(s, BLANK_LAYOUT);
+
+      expect(result.fallbackToBlank).toBe(true);
+      expect(result.layoutName).toBe("Blank");
+      expect(result.assignments).toHaveLength(0);
+      expect(result.unmappedContent).toHaveLength(2);
+    });
+
+    it("titleプレースホルダがない場合、見出しはunmappedになる", () => {
+      const bodyOnlyLayout: LayoutInfo = {
+        name: "Body Only",
+        placeholders: [{ idx: 1, type: "body", name: "Body 1" }],
+      };
+      const s = slide([heading(1, "タイトル"), paragraph("本文")]);
+      const result = mapSlideToPlaceholders(s, bodyOnlyLayout);
+
+      expect(result.unmappedContent).toHaveLength(1);
+      expect(result.unmappedContent[0].type).toBe("heading");
+
+      const bodyAssignment = result.assignments.find(
+        (a) => a.placeholderType === "body",
+      );
+      expect(bodyAssignment!.content).toHaveLength(1);
+    });
+
+    it("空のスライドではassignmentsもunmappedも空になる", () => {
+      const s = slide([]);
+      const result = mapSlideToPlaceholders(s, TITLE_AND_CONTENT_LAYOUT);
+
+      expect(result.assignments).toHaveLength(0);
+      expect(result.unmappedContent).toHaveLength(0);
+      expect(result.fallbackToBlank).toBe(false);
+    });
+  });
+});
+
+describe("mapPresentation", () => {
+  const templateInfo: TemplateInfo = {
+    layouts: [
+      TITLE_AND_CONTENT_LAYOUT,
+      PICTURE_LAYOUT,
+      BLANK_LAYOUT,
+      TITLE_ONLY_LAYOUT,
+    ],
+  };
+
+  it("各スライドのlayoutに応じてマッピングし、assignmentsの詳細が正しい", () => {
+    const parseResult: ParseResult = {
+      frontMatter: {},
+      slides: [
+        slide(
+          [heading(1, "スライド1"), paragraph("本文1")],
+          "Title and Content",
+        ),
+        slide(
+          [heading(1, "スライド2"), image("photo.png")],
+          "Picture with Caption",
+        ),
+      ],
+    };
+
+    const results = mapPresentation(parseResult, templateInfo);
+
+    expect(results).toHaveLength(2);
+
+    // スライド1: Title and Content
+    expect(results[0].layoutName).toBe("Title and Content");
+    expect(results[0].assignments).toHaveLength(2);
+    const s1Title = results[0].assignments.find(
+      (a) => a.placeholderType === "title",
+    );
+    expect(s1Title!.placeholderIdx).toBe(0);
+    expect(s1Title!.content[0].type).toBe("heading");
+    const s1Body = results[0].assignments.find(
+      (a) => a.placeholderType === "body",
+    );
+    expect(s1Body!.placeholderIdx).toBe(1);
+    expect(s1Body!.content[0].type).toBe("paragraph");
+
+    // スライド2: Picture with Caption
+    expect(results[1].layoutName).toBe("Picture with Caption");
+    const s2Title = results[1].assignments.find(
+      (a) => a.placeholderType === "title",
+    );
+    expect(s2Title!.placeholderIdx).toBe(0);
+    const s2Pic = results[1].assignments.find(
+      (a) => a.placeholderType === "picture",
+    );
+    expect(s2Pic!.placeholderIdx).toBe(2);
+    expect(s2Pic!.content[0].type).toBe("image");
+  });
+
+  it("レイアウトが見つからない場合Blankにフォールバックする", () => {
+    const parseResult: ParseResult = {
+      frontMatter: {},
+      slides: [
+        slide(
+          [heading(1, "タイトル"), paragraph("本文")],
+          "Non Existent Layout",
+        ),
+      ],
+    };
+
+    const results = mapPresentation(parseResult, templateInfo);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].fallbackToBlank).toBe(true);
+    expect(results[0].layoutName).toBe("Blank");
+    expect(results[0].unmappedContent).toHaveLength(2);
+  });
+
+  it("layoutが未指定のスライドはBlankにフォールバックする", () => {
+    const parseResult: ParseResult = {
+      frontMatter: {},
+      slides: [slide([heading(1, "タイトル"), paragraph("本文")])],
+    };
+
+    const results = mapPresentation(parseResult, templateInfo);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].fallbackToBlank).toBe(true);
+    expect(results[0].layoutName).toBe("Blank");
+  });
+
+  it("テンプレートにBlankレイアウトがあればフォールバック時にそれを使う", () => {
+    const blankWithBody: LayoutInfo = {
+      name: "Blank",
+      placeholders: [{ idx: 1, type: "body", name: "Body 1" }],
+    };
+    const templateWithBlankBody: TemplateInfo = {
+      layouts: [TITLE_AND_CONTENT_LAYOUT, blankWithBody],
+    };
+    const parseResult: ParseResult = {
+      frontMatter: {},
+      slides: [slide([paragraph("本文")], "Non Existent Layout")],
+    };
+
+    const results = mapPresentation(parseResult, templateWithBlankBody);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].fallbackToBlank).toBe(false);
+    expect(results[0].layoutName).toBe("Blank");
+    const bodyAssignment = results[0].assignments.find(
+      (a) => a.placeholderType === "body",
+    );
+    expect(bodyAssignment).toBeDefined();
+    expect(bodyAssignment!.content).toHaveLength(1);
+  });
+});

--- a/src/__tests__/placeholder-utils.test.ts
+++ b/src/__tests__/placeholder-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { toPlaceholderType, findLayout } from "../placeholder-utils.js";
+import type { TemplateInfo } from "../types.js";
+
+describe("toPlaceholderType", () => {
+  it("CENTER_TITLE (1) を title に変換する", () => {
+    expect(toPlaceholderType(1)).toBe("title");
+  });
+
+  it("TITLE (15) を title に変換する", () => {
+    expect(toPlaceholderType(15)).toBe("title");
+  });
+
+  it("BODY (2) を body に変換する", () => {
+    expect(toPlaceholderType(2)).toBe("body");
+  });
+
+  it("SUBTITLE (3) を subtitle に変換する", () => {
+    expect(toPlaceholderType(3)).toBe("subtitle");
+  });
+
+  it("PICTURE (18) を picture に変換する", () => {
+    expect(toPlaceholderType(18)).toBe("picture");
+  });
+
+  it("未知の数値を other に変換する", () => {
+    expect(toPlaceholderType(0)).toBe("other");
+    expect(toPlaceholderType(99)).toBe("other");
+    expect(toPlaceholderType(-1)).toBe("other");
+  });
+});
+
+describe("findLayout", () => {
+  const templateInfo: TemplateInfo = {
+    layouts: [
+      { name: "Title Slide", placeholders: [] },
+      { name: "Title and Content", placeholders: [] },
+      { name: "Blank", placeholders: [] },
+    ],
+  };
+
+  it("名前でレイアウトを検索できる", () => {
+    const result = findLayout(templateInfo, "Title Slide");
+    expect(result).toBeDefined();
+    expect(result!.name).toBe("Title Slide");
+  });
+
+  it("存在しないレイアウト名で undefined を返す", () => {
+    const result = findLayout(templateInfo, "Non Existent");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export { parseMarkdown } from "./parser.js";
+export { readTemplate } from "./template-reader.js";
+export { findLayout, toPlaceholderType } from "./placeholder-utils.js";
+export {
+  mapSlideToPlaceholders,
+  mapPresentation,
+} from "./placeholder-mapper.js";
 export type {
   ParseResult,
   FrontMatter,
@@ -13,4 +19,10 @@ export type {
   ImageData,
   Directive,
   DirectiveScope,
+  PlaceholderType,
+  PlaceholderInfo,
+  LayoutInfo,
+  TemplateInfo,
+  PlaceholderAssignment,
+  SlideMappingResult,
 } from "./types.js";

--- a/src/placeholder-mapper.ts
+++ b/src/placeholder-mapper.ts
@@ -1,0 +1,136 @@
+import type {
+  ContentElement,
+  LayoutInfo,
+  ParseResult,
+  PlaceholderAssignment,
+  PlaceholderInfo,
+  PlaceholderType,
+  SlideMappingResult,
+  SlideData,
+  TemplateInfo,
+} from "./types.js";
+import { findLayout } from "./placeholder-utils.js";
+
+const BLANK_LAYOUT: LayoutInfo = { name: "Blank", placeholders: [] };
+
+function findPlaceholder(
+  layout: LayoutInfo,
+  type: PlaceholderType,
+): PlaceholderInfo | undefined {
+  return layout.placeholders.find((p) => p.type === type);
+}
+
+export function mapSlideToPlaceholders(
+  slide: SlideData,
+  layout: LayoutInfo,
+): SlideMappingResult {
+  const titlePh = findPlaceholder(layout, "title");
+  const subtitlePh = findPlaceholder(layout, "subtitle");
+  const bodyPh = findPlaceholder(layout, "body");
+  const picturePh = findPlaceholder(layout, "picture");
+
+  const titleContent: ContentElement[] = [];
+  const subtitleContent: ContentElement[] = [];
+  const bodyContent: ContentElement[] = [];
+  const pictureContent: ContentElement[] = [];
+  const unmappedContent: ContentElement[] = [];
+
+  let titleAssigned = false;
+
+  for (const element of slide.content) {
+    if (
+      !titleAssigned &&
+      element.type === "heading" &&
+      (element.level === 1 || element.level === 2)
+    ) {
+      titleAssigned = true;
+      const targetPh = titlePh ?? subtitlePh;
+      if (targetPh) {
+        if (targetPh === subtitlePh) {
+          subtitleContent.push(element);
+        } else {
+          titleContent.push(element);
+        }
+      } else {
+        unmappedContent.push(element);
+      }
+    } else if (element.type === "image") {
+      if (picturePh) {
+        pictureContent.push(element);
+      } else if (bodyPh) {
+        bodyContent.push(element);
+      } else {
+        unmappedContent.push(element);
+      }
+    } else {
+      if (bodyPh) {
+        bodyContent.push(element);
+      } else {
+        unmappedContent.push(element);
+      }
+    }
+  }
+
+  const assignments: PlaceholderAssignment[] = [];
+
+  if (titlePh && titleContent.length > 0) {
+    assignments.push({
+      placeholderIdx: titlePh.idx,
+      placeholderType: titlePh.type,
+      content: titleContent,
+    });
+  }
+
+  if (subtitlePh && subtitleContent.length > 0) {
+    assignments.push({
+      placeholderIdx: subtitlePh.idx,
+      placeholderType: subtitlePh.type,
+      content: subtitleContent,
+    });
+  }
+
+  if (bodyPh && bodyContent.length > 0) {
+    assignments.push({
+      placeholderIdx: bodyPh.idx,
+      placeholderType: bodyPh.type,
+      content: bodyContent,
+    });
+  }
+
+  if (picturePh && pictureContent.length > 0) {
+    assignments.push({
+      placeholderIdx: picturePh.idx,
+      placeholderType: picturePh.type,
+      content: pictureContent,
+    });
+  }
+
+  const fallbackToBlank =
+    unmappedContent.length > 0 && assignments.length === 0;
+
+  return {
+    layoutName: fallbackToBlank ? "Blank" : layout.name,
+    assignments,
+    fallbackToBlank,
+    unmappedContent,
+  };
+}
+
+export function mapPresentation(
+  parseResult: ParseResult,
+  templateInfo: TemplateInfo,
+): SlideMappingResult[] {
+  return parseResult.slides.map((slide: SlideData) => {
+    const layoutName = slide.layout;
+    const layout = layoutName
+      ? findLayout(templateInfo, layoutName)
+      : undefined;
+
+    if (!layout) {
+      const blankLayout = findLayout(templateInfo, "Blank") ?? BLANK_LAYOUT;
+      return mapSlideToPlaceholders(slide, blankLayout);
+    }
+
+    return mapSlideToPlaceholders(slide, layout);
+  });
+}

--- a/src/placeholder-utils.ts
+++ b/src/placeholder-utils.ts
@@ -1,0 +1,33 @@
+import type { PlaceholderType, LayoutInfo, TemplateInfo } from "./types.js";
+
+/**
+ * python-pptx の PP_PLACEHOLDER_TYPE 数値を PlaceholderType 文字列に変換する。
+ *
+ * 参照: https://python-pptx.readthedocs.io/en/latest/api/enum/PpPlaceholderType.html
+ *   1 = CENTER_TITLE, 15 = TITLE → "title"
+ *   2 = BODY → "body"
+ *   3 = SUBTITLE → "subtitle"
+ *   18 = PICTURE → "picture"
+ */
+export function toPlaceholderType(rawType: number): PlaceholderType {
+  switch (rawType) {
+    case 1: // CENTER_TITLE
+    case 15: // TITLE
+      return "title";
+    case 2: // BODY
+      return "body";
+    case 3: // SUBTITLE
+      return "subtitle";
+    case 18: // PICTURE
+      return "picture";
+    default:
+      return "other";
+  }
+}
+
+export function findLayout(
+  templateInfo: TemplateInfo,
+  name: string,
+): LayoutInfo | undefined {
+  return templateInfo.layouts.find((l) => l.name === name);
+}

--- a/src/template-reader.ts
+++ b/src/template-reader.ts
@@ -1,0 +1,44 @@
+import { Presentation } from "python-pptx-wasm";
+import type { PlaceholderInfo, LayoutInfo, TemplateInfo } from "./types.js";
+import { toPlaceholderType } from "./placeholder-utils.js";
+
+export { toPlaceholderType, findLayout } from "./placeholder-utils.js";
+
+export function readTemplate(data?: Uint8Array): TemplateInfo {
+  const prs = data ? Presentation(data) : Presentation();
+
+  try {
+    const layouts: LayoutInfo[] = [];
+    const slideLayouts = prs.slide_layouts;
+
+    for (let i = 0; i < slideLayouts.length; i++) {
+      const layout = slideLayouts.getItem(i);
+      const placeholders: PlaceholderInfo[] = [];
+      const phs = layout.placeholders;
+
+      for (let j = 0; j < phs.length; j++) {
+        const ph = phs.getItem(j) as Record<string, unknown>;
+        const fmt = ph.placeholder_format as
+          | { idx?: number; type?: number }
+          | undefined;
+
+        if (fmt && fmt.idx != null) {
+          placeholders.push({
+            idx: fmt.idx,
+            type: toPlaceholderType(fmt.type ?? -1),
+            name: typeof ph.name === "string" ? ph.name : "",
+          });
+        }
+      }
+
+      layouts.push({
+        name: layout.name ?? "",
+        placeholders,
+      });
+    }
+
+    return { layouts };
+  } finally {
+    prs.end();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,3 +88,42 @@ export interface ParseResult {
   frontMatter: FrontMatter;
   slides: SlideData[];
 }
+
+// === Template / Placeholder ===
+
+export type PlaceholderType =
+  | "title"
+  | "body"
+  | "picture"
+  | "subtitle"
+  | "other";
+
+export interface PlaceholderInfo {
+  idx: number;
+  type: PlaceholderType;
+  name: string;
+}
+
+export interface LayoutInfo {
+  name: string;
+  placeholders: PlaceholderInfo[];
+}
+
+export interface TemplateInfo {
+  layouts: LayoutInfo[];
+}
+
+// === Placeholder Mapping ===
+
+export interface PlaceholderAssignment {
+  placeholderIdx: number;
+  placeholderType: PlaceholderType;
+  content: ContentElement[];
+}
+
+export interface SlideMappingResult {
+  layoutName: string;
+  assignments: PlaceholderAssignment[];
+  fallbackToBlank: boolean;
+  unmappedContent: ContentElement[];
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     globals: true,
+    server: {
+      deps: {
+        inline: ["python-pptx-wasm"],
+      },
+    },
   },
 });


### PR DESCRIPTION
close #9

## 概要

テンプレートPPTXを読み込み、Markdownの構造をプレースホルダにマッピングするコアロジックを実装。

- **template-reader**: python-pptx-wasmでテンプレートPPTX読み込み・レイアウト/プレースホルダ情報抽出
- **placeholder-utils**: PP_PLACEHOLDER_TYPE数値→文字列変換、レイアウト検索（純粋関数、テスト容易）
- **placeholder-mapper**: Markdown構造→プレースホルダtype/idxマッピング
  - `# 見出し` (h1/h2) → titleプレースホルダ（subtitleフォールバック対応）
  - 本文テキスト・リスト → bodyプレースホルダ
  - `![](img)` → pictureプレースホルダ（なければbody内に配置）
  - プレースホルダ不足/存在しない場合のBlankレイアウトフォールバック
- **型定義追加**: PlaceholderType, PlaceholderInfo, LayoutInfo, TemplateInfo, PlaceholderAssignment, SlideMappingResult

## 設計判断

- python-pptx-wasm依存のテンプレート読み込みと純粋なマッピングロジックを分離し、マッピングロジックを単体テスト可能に
- vitest設定にpython-pptx-wasmのinline deps追加で既存テストとの互換性を維持

## テスト計画

- [x] placeholder-utils: toPlaceholderType（全type変換）、findLayout（検索・未検出）
- [x] placeholder-mapper: 基本マッピング、subtitle対応、画像マッピング、フォールバック、mapPresentation統合テスト
- [x] typecheck / lint / format:check 通過
- [x] 全96テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)