### PR TITLE
feat: CLI実装（build / inspect コマンド）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "commander": "^14.0.3",
         "jszip": "^3.10.1",
         "markdown-it": "^14.1.1",
         "pyodide": "^0.28.3",
@@ -1935,13 +1936,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 6"
+        "node": ">=20"
       }
     },
     "node_modules/confbox": {
@@ -3513,6 +3513,16 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/thenify": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "bin": {
+    "md-pptx": "./dist/cli.js"
+  },
   "files": [
     "dist"
   ],
@@ -22,6 +25,7 @@
   "keywords": [],
   "license": "ISC",
   "dependencies": {
+    "commander": "^14.0.3",
     "jszip": "^3.10.1",
     "markdown-it": "^14.1.1",
     "pyodide": "^0.28.3",

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  writeFileSync,
+  readFileSync,
+  mkdtempSync,
+  rmSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+vi.mock("../parser.js", () => ({
+  parseMarkdown: vi.fn(() => ({
+    frontMatter: {},
+    slides: [{ layout: undefined, content: [], notes: [], directives: [] }],
+  })),
+}));
+
+vi.mock("../template-reader.js", () => ({
+  readTemplate: vi.fn(() => ({
+    layouts: [
+      {
+        name: "Title Slide",
+        placeholders: [
+          { idx: 0, type: "title", name: "Title 1" },
+          { idx: 1, type: "subtitle", name: "Subtitle 2" },
+        ],
+      },
+      { name: "Blank", placeholders: [] },
+    ],
+  })),
+}));
+
+vi.mock("../placeholder-mapper.js", () => ({
+  mapPresentation: vi.fn(() => [
+    {
+      layoutName: "Blank",
+      assignments: [],
+      fallbackToBlank: true,
+      unmappedContent: [],
+    },
+  ]),
+}));
+
+vi.mock("../pptx-generator.js", () => ({
+  generatePptx: vi.fn(() => new Uint8Array([0x50, 0x4b, 0x03, 0x04])),
+}));
+
+import { parseMarkdown } from "../parser.js";
+import { readTemplate } from "../template-reader.js";
+import { mapPresentation } from "../placeholder-mapper.js";
+import { generatePptx } from "../pptx-generator.js";
+import { buildAction, inspectAction, createProgram } from "../cli.js";
+
+describe("CLI", () => {
+  describe("createProgram", () => {
+    it("プログラム名とバージョンが設定されている", () => {
+      const program = createProgram();
+      expect(program.name()).toBe("md-pptx");
+      expect(program.version()).toBe("0.0.0");
+    });
+
+    it("build と inspect サブコマンドが登録されている", () => {
+      const program = createProgram();
+      const commandNames = program.commands.map((c) => c.name());
+      expect(commandNames).toContain("build");
+      expect(commandNames).toContain("inspect");
+    });
+
+    it("build サブコマンドが引数経由で実行される", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "md-pptx-test-"));
+      const mdPath = join(tmpDir, "test.md");
+      writeFileSync(mdPath, "# Hello");
+
+      vi.clearAllMocks();
+      const program = createProgram();
+      program.parse(["node", "md-pptx", "build", mdPath]);
+
+      expect(parseMarkdown).toHaveBeenCalled();
+      expect(existsSync(join(tmpDir, "test.pptx"))).toBe(true);
+
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("inspect サブコマンドが引数経由で実行される", () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), "md-pptx-test-"));
+      const templatePath = join(tmpDir, "template.pptx");
+      writeFileSync(templatePath, "fake-pptx-data");
+
+      vi.clearAllMocks();
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const program = createProgram();
+      program.parse(["node", "md-pptx", "inspect", templatePath]);
+
+      expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("レイアウト数: 2");
+
+      consoleSpy.mockRestore();
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("buildAction", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "md-pptx-test-"));
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("Markdown をパースして PPTX を出力する", () => {
+      const mdPath = join(tmpDir, "test.md");
+      writeFileSync(mdPath, "# Hello\n\nWorld");
+
+      buildAction(mdPath, {});
+
+      expect(parseMarkdown).toHaveBeenCalledWith("# Hello\n\nWorld");
+      expect(readTemplate).toHaveBeenCalledWith(undefined);
+      expect(mapPresentation).toHaveBeenCalled();
+      expect(generatePptx).toHaveBeenCalled();
+
+      const outputPath = join(tmpDir, "test.pptx");
+      expect(existsSync(outputPath)).toBe(true);
+      const outputData = readFileSync(outputPath);
+      expect(outputData[0]).toBe(0x50);
+      expect(outputData[1]).toBe(0x4b);
+    });
+
+    it("--output オプションで出力先を指定できる", () => {
+      const mdPath = join(tmpDir, "test.md");
+      const outputPath = join(tmpDir, "custom-output.pptx");
+      writeFileSync(mdPath, "# Test");
+
+      buildAction(mdPath, { output: outputPath });
+
+      expect(existsSync(outputPath)).toBe(true);
+    });
+
+    it("--template オプションでテンプレートを指定できる", () => {
+      const mdPath = join(tmpDir, "test.md");
+      const templatePath = join(tmpDir, "template.pptx");
+      writeFileSync(mdPath, "# Test");
+      writeFileSync(templatePath, "fake-pptx-data");
+
+      buildAction(mdPath, { template: templatePath });
+
+      expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
+    });
+
+    it("frontmatter の template パスを使用する", () => {
+      const mdPath = join(tmpDir, "test.md");
+      const templatePath = join(tmpDir, "tmpl.pptx");
+      writeFileSync(mdPath, "---\ntemplate: tmpl.pptx\n---\n# Test");
+      writeFileSync(templatePath, "fake-pptx-data");
+
+      vi.mocked(parseMarkdown).mockReturnValueOnce({
+        frontMatter: { template: "tmpl.pptx" },
+        slides: [{ layout: undefined, content: [], notes: [], directives: [] }],
+      });
+
+      buildAction(mdPath, {});
+
+      expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
+    });
+
+    it("存在しない Markdown ファイルでエラーを投げる", () => {
+      expect(() => {
+        buildAction(join(tmpDir, "nonexistent.md"), {});
+      }).toThrow();
+    });
+  });
+
+  describe("inspectAction", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "md-pptx-test-"));
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("テンプレートのレイアウト情報を表示する", () => {
+      const templatePath = join(tmpDir, "template.pptx");
+      writeFileSync(templatePath, "fake-pptx-data");
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      inspectAction(templatePath);
+
+      expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      expect(output).toContain("レイアウト数: 2");
+      expect(output).toContain("[Title Slide]");
+      expect(output).toContain("idx: 0, type: title, name: Title 1");
+      expect(output).toContain("[Blank]");
+      expect(output).toContain("(プレースホルダなし)");
+
+      consoleSpy.mockRestore();
+    });
+
+    it("存在しないテンプレートファイルでエラーを投げる", () => {
+      expect(() => {
+        inspectAction(join(tmpDir, "nonexistent.pptx"));
+      }).toThrow();
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,135 @@
+import { readFileSync, writeFileSync, realpathSync } from "node:fs";
+import { resolve, dirname, basename, extname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Command } from "commander";
+import { parseMarkdown } from "./parser.js";
+import { readTemplate } from "./template-reader.js";
+import { mapPresentation } from "./placeholder-mapper.js";
+import { generatePptx } from "./pptx-generator.js";
+
+export function buildAction(
+  markdownPath: string,
+  options: { template?: string; output?: string },
+): void {
+  const resolvedMdPath = resolve(markdownPath);
+  const mdContent = readFileSync(resolvedMdPath, "utf-8");
+  const mdDir = dirname(resolvedMdPath);
+
+  const parseResult = parseMarkdown(mdContent);
+
+  const templatePath = options.template ?? parseResult.frontMatter.template;
+  let templateData: Uint8Array | undefined;
+  if (templatePath) {
+    const resolvedTemplatePath = resolve(mdDir, templatePath);
+    templateData = new Uint8Array(readFileSync(resolvedTemplatePath));
+  }
+
+  const templateInfo = readTemplate(templateData);
+  const mappingResults = mapPresentation(parseResult, templateInfo);
+
+  const imageResolver = (src: string): Uint8Array | undefined => {
+    try {
+      const imagePath = resolve(mdDir, src);
+      return new Uint8Array(readFileSync(imagePath));
+    } catch {
+      console.error(`Warning: 画像ファイルが見つかりません: ${src}`);
+      return undefined;
+    }
+  };
+
+  const pptxData = generatePptx(parseResult, mappingResults, {
+    templateData,
+    imageResolver,
+  });
+
+  const outputPath =
+    options.output ??
+    join(
+      dirname(resolvedMdPath),
+      basename(resolvedMdPath, extname(resolvedMdPath)) + ".pptx",
+    );
+  const resolvedOutputPath = resolve(outputPath);
+  writeFileSync(resolvedOutputPath, pptxData);
+
+  console.log(`PPTX を生成しました: ${resolvedOutputPath}`);
+}
+
+export function inspectAction(templatePath: string): void {
+  const resolvedPath = resolve(templatePath);
+  const data = new Uint8Array(readFileSync(resolvedPath));
+  const templateInfo = readTemplate(data);
+
+  console.log(`テンプレート: ${resolvedPath}`);
+  console.log(`レイアウト数: ${templateInfo.layouts.length}`);
+  console.log("");
+
+  for (const layout of templateInfo.layouts) {
+    console.log(`  [${layout.name}]`);
+    if (layout.placeholders.length === 0) {
+      console.log("    (プレースホルダなし)");
+    } else {
+      for (const ph of layout.placeholders) {
+        console.log(`    - idx: ${ph.idx}, type: ${ph.type}, name: ${ph.name}`);
+      }
+    }
+    console.log("");
+  }
+}
+
+export function createProgram(): Command {
+  const program = new Command();
+
+  program
+    .name("md-pptx")
+    .description("Marp風Markdown → テンプレートPPTX出力ツール")
+    .version("0.0.0");
+
+  program
+    .command("build")
+    .description("MarkdownファイルからPPTXを生成する")
+    .argument("<markdown>", "Markdownファイルパス")
+    .option("-t, --template <path>", "テンプレートPPTXパス")
+    .option("-o, --output <path>", "出力先パス")
+    .action(
+      (
+        markdownPath: string,
+        options: { template?: string; output?: string },
+      ) => {
+        try {
+          buildAction(markdownPath, options);
+        } catch (error) {
+          console.error(
+            `Error: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          process.exitCode = 1;
+        }
+      },
+    );
+
+  program
+    .command("inspect")
+    .description("テンプレートPPTXのレイアウト情報を表示する")
+    .argument("<template>", "テンプレートPPTXパス")
+    .action((templatePath: string) => {
+      try {
+        inspectAction(templatePath);
+      } catch (error) {
+        console.error(
+          `Error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        process.exitCode = 1;
+      }
+    });
+
+  return program;
+}
+
+const thisFile = fileURLToPath(import.meta.url);
+const argFile = process.argv[1];
+const isDirectRun =
+  argFile &&
+  (argFile === thisFile || realpathSync(argFile) === realpathSync(thisFile));
+
+if (isDirectRun) {
+  createProgram().parse();
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,9 +1,20 @@
 import { defineConfig } from "tsup";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
+const shared = {
+  format: ["esm"] as const,
   dts: true,
-  clean: true,
   sourcemap: true,
-});
+};
+
+export default defineConfig([
+  {
+    entry: ["src/index.ts"],
+    clean: true,
+    ...shared,
+  },
+  {
+    entry: ["src/cli.ts"],
+    banner: { js: "#!/usr/bin/env node" },
+    ...shared,
+  },
+]);


### PR DESCRIPTION
close #11

## Summary
- `md-pptx build <markdown>` コマンドを実装（Markdown + テンプレートPPTXからPPTX生成）
  - `--template, -t` でテンプレートPPTX指定（frontmatterの `template` より優先）
  - `--output, -o` で出力先指定（デフォルト: 入力ファイル名.pptx）
  - 画像をMarkdownファイルからの相対パスで解決
- `md-pptx inspect <template>` コマンドを実装（テンプレートPPTXのレイアウト・プレースホルダ情報表示）
- CLIフレームワークに commander を採用
- `--version` / `--help` 表示対応
- エラーハンドリング・メッセージ表示

## 変更ファイル
- `src/cli.ts` — CLIエントリポイント（新規）
- `src/__tests__/cli.test.ts` — CLIテスト（新規）
- `package.json` — `bin` フィールド追加、commander 依存追加
- `tsup.config.ts` — cli.ts エントリ追加、shebang 付与

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` 全126テスト通過
- [x] `npm run build` 成功、shebang 付与確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)