### PR TITLE
feat: スライドマスター背景画像の抽出機能

### DIFF
--- a/src/__tests__/slide-master-extractor.test.ts
+++ b/src/__tests__/slide-master-extractor.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from "vitest";
+import JSZip from "jszip";
+import { extractBackgrounds } from "../slide-master-extractor.js";
+
+/** テスト用のPPTXバイナリを生成するヘルパー */
+async function createTestPptx(
+  files: Record<string, string | Uint8Array>,
+): Promise<Uint8Array> {
+  const zip = new JSZip();
+  for (const [path, content] of Object.entries(files)) {
+    zip.file(path, content);
+  }
+  const buf = await zip.generateAsync({ type: "arraybuffer" });
+  return new Uint8Array(buf);
+}
+
+// 1x1 PNG画像のバイナリ（最小限の有効なPNG）
+const TINY_PNG = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49,
+  0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02,
+  0x00, 0x00, 0x00, 0x90, 0x77, 0x53, 0xde, 0x00, 0x00, 0x00, 0x0c, 0x49, 0x44,
+  0x41, 0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00, 0x00, 0x02, 0x00,
+  0x01, 0xe2, 0x21, 0xbc, 0x33, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+function slideMasterXml(name: string, rId: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld name="${name}">
+    <p:bg>
+      <p:bgPr>
+        <a:blipFill>
+          <a:blip r:embed="${rId}"/>
+          <a:stretch><a:fillRect/></a:stretch>
+        </a:blipFill>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+}
+
+function slideLayoutXml(name: string, rId?: string): string {
+  const bgSection = rId
+    ? `<p:bg>
+      <p:bgPr>
+        <a:blipFill>
+          <a:blip r:embed="${rId}"/>
+          <a:stretch><a:fillRect/></a:stretch>
+        </a:blipFill>
+      </p:bgPr>
+    </p:bg>`
+    : "";
+
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+             xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+             xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld name="${name}">
+    ${bgSection}
+    <p:spTree/>
+  </p:cSld>
+</p:sldLayout>`;
+}
+
+function relsXml(rId: string, target: string): string {
+  return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="${rId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="${target}"/>
+</Relationships>`;
+}
+
+describe("extractBackgrounds", () => {
+  describe("スライドマスター背景の抽出", () => {
+    it("背景画像を持つスライドマスターから画像を抽出できる", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "TestMaster",
+          "rId2",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/image1.png",
+        ),
+        "ppt/media/image1.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(1);
+      expect(result.masters[0].masterName).toBe("TestMaster");
+      expect(result.masters[0].contentType).toBe("image/png");
+      expect(result.masters[0].data).toEqual(TINY_PNG);
+      expect(result.masters[0].dataUrl).toMatch(
+        /^data:image\/png;base64,[A-Za-z0-9+/=]+$/,
+      );
+    });
+
+    it("背景画像がないスライドマスターは結果に含まれない", async () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sldMaster xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld name="NoBackground">
+    <p:spTree/>
+  </p:cSld>
+</p:sldMaster>`;
+
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": xml,
+      });
+
+      const result = await extractBackgrounds(pptx);
+      expect(result.masters).toHaveLength(0);
+    });
+
+    it("複数のスライドマスターから背景画像を抽出できる", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml("Master1", "rId2"),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/image1.png",
+        ),
+        "ppt/media/image1.png": TINY_PNG,
+        "ppt/slideMasters/slideMaster2.xml": slideMasterXml("Master2", "rId3"),
+        "ppt/slideMasters/_rels/slideMaster2.xml.rels": relsXml(
+          "rId3",
+          "../media/image2.png",
+        ),
+        "ppt/media/image2.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(2);
+      expect(result.masters[0].masterName).toBe("Master1");
+      expect(result.masters[1].masterName).toBe("Master2");
+    });
+
+    it("JPEG画像の場合にMIMEタイプが正しく判定される", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "TestMaster",
+          "rId2",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/image1.jpeg",
+        ),
+        "ppt/media/image1.jpeg": TINY_PNG, // 拡張子だけ変えてテスト
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(1);
+      expect(result.masters[0].contentType).toBe("image/jpeg");
+    });
+  });
+
+  describe("スライドレイアウト背景の抽出", () => {
+    it("背景画像を持つスライドレイアウトから画像を抽出できる", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideLayouts/slideLayout1.xml": slideLayoutXml(
+          "TitleLayout",
+          "rId2",
+        ),
+        "ppt/slideLayouts/_rels/slideLayout1.xml.rels": relsXml(
+          "rId2",
+          "../media/image1.png",
+        ),
+        "ppt/media/image1.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.layouts).toHaveLength(1);
+      expect(result.layouts[0].layoutName).toBe("TitleLayout");
+      expect(result.layouts[0].contentType).toBe("image/png");
+      expect(result.layouts[0].data).toEqual(TINY_PNG);
+    });
+
+    it("背景画像がないスライドレイアウトは結果に含まれない", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideLayouts/slideLayout1.xml": slideLayoutXml("BlankLayout"),
+      });
+
+      const result = await extractBackgrounds(pptx);
+      expect(result.layouts).toHaveLength(0);
+    });
+  });
+
+  describe("エッジケース", () => {
+    it("スライドマスターもレイアウトもない場合は空の結果を返す", async () => {
+      const pptx = await createTestPptx({
+        "[Content_Types].xml": '<?xml version="1.0"?><Types/>',
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(0);
+      expect(result.layouts).toHaveLength(0);
+    });
+
+    it("relsファイルが存在しない場合はスキップする", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "TestMaster",
+          "rId2",
+        ),
+        // _rels ファイルなし
+      });
+
+      const result = await extractBackgrounds(pptx);
+      expect(result.masters).toHaveLength(0);
+    });
+
+    it("メディアファイルが存在しない場合はスキップする", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "TestMaster",
+          "rId2",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/missing.png",
+        ),
+        // メディアファイルなし
+      });
+
+      const result = await extractBackgrounds(pptx);
+      expect(result.masters).toHaveLength(0);
+    });
+
+    it("relsにマッチするリレーションシップがない場合はスキップする", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "TestMaster",
+          "rId99",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/image1.png",
+        ),
+        "ppt/media/image1.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+      expect(result.masters).toHaveLength(0);
+    });
+
+    it("Targetがルート絶対パスの場合でも画像を抽出できる", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "AbsPathMaster",
+          "rId2",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "/ppt/media/image1.png",
+        ),
+        "ppt/media/image1.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(1);
+      expect(result.masters[0].masterName).toBe("AbsPathMaster");
+      expect(result.masters[0].data).toEqual(TINY_PNG);
+    });
+
+    it("Relationship属性の順序がTarget→Idでも画像を抽出できる", async () => {
+      const altRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Target="../media/image1.png" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Id="rId2"/>
+</Relationships>`;
+
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml(
+          "AltOrderMaster",
+          "rId2",
+        ),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": altRelsXml,
+        "ppt/media/image1.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(1);
+      expect(result.masters[0].masterName).toBe("AltOrderMaster");
+    });
+
+    it("マスターとレイアウトの両方から同時に抽出できる", async () => {
+      const pptx = await createTestPptx({
+        "ppt/slideMasters/slideMaster1.xml": slideMasterXml("Master", "rId2"),
+        "ppt/slideMasters/_rels/slideMaster1.xml.rels": relsXml(
+          "rId2",
+          "../media/bg-master.png",
+        ),
+        "ppt/media/bg-master.png": TINY_PNG,
+        "ppt/slideLayouts/slideLayout1.xml": slideLayoutXml("Layout", "rId3"),
+        "ppt/slideLayouts/_rels/slideLayout1.xml.rels": relsXml(
+          "rId3",
+          "../media/bg-layout.png",
+        ),
+        "ppt/media/bg-layout.png": TINY_PNG,
+      });
+
+      const result = await extractBackgrounds(pptx);
+
+      expect(result.masters).toHaveLength(1);
+      expect(result.masters[0].masterName).toBe("Master");
+      expect(result.layouts).toHaveLength(1);
+      expect(result.layouts[0].layoutName).toBe("Layout");
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export {
 } from "./placeholder-mapper.js";
 export { generatePptx } from "./pptx-generator.js";
 export type { GenerateOptions } from "./pptx-generator.js";
+export { extractBackgrounds } from "./slide-master-extractor.js";
 export type {
   ParseResult,
   FrontMatter,
@@ -27,4 +28,7 @@ export type {
   TemplateInfo,
   PlaceholderAssignment,
   SlideMappingResult,
+  SlideMasterBackground,
+  SlideLayoutBackground,
+  BackgroundExtractionResult,
 } from "./types.js";

--- a/src/slide-master-extractor.ts
+++ b/src/slide-master-extractor.ts
@@ -1,0 +1,209 @@
+import JSZip from "jszip";
+import type {
+  SlideMasterBackground,
+  SlideLayoutBackground,
+  BackgroundExtractionResult,
+} from "./types.js";
+
+/**
+ * PPTXバイナリからスライドマスター・スライドレイアウトの背景画像を抽出する。
+ */
+export async function extractBackgrounds(
+  pptxData: Uint8Array,
+): Promise<BackgroundExtractionResult> {
+  const zip = await JSZip.loadAsync(pptxData);
+
+  const masters = await extractSlideMasterBackgrounds(zip);
+  const layouts = await extractSlideLayoutBackgrounds(zip);
+
+  return { masters, layouts };
+}
+
+/** XMLテキストから blipFill 内の r:embed 属性値を取得する */
+function findBackgroundBlipEmbed(xml: string): string | undefined {
+  // <p:bg> 要素内の <a:blip r:embed="rIdX"/> を探す
+  const bgMatch = xml.match(/<p:bg\b[^>]*>([\s\S]*?)<\/p:bg>/);
+  if (!bgMatch) return undefined;
+
+  const bgContent = bgMatch[1];
+  const blipMatch = bgContent.match(/<a:blip\b[^>]*r:embed="([^"]+)"/);
+  return blipMatch?.[1];
+}
+
+/** .rels ファイルからリレーションシップIDに対応するTargetパスを取得する */
+function resolveRelationship(relsXml: string, rId: string): string | undefined {
+  const escapedId = rId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `<Relationship\\b[^>]*Id="${escapedId}"[^>]*Target="([^"]+)"`,
+  );
+  const match = relsXml.match(pattern);
+  if (match) return match[1];
+
+  // Target が Id の前に来るケースにも対応
+  const altPattern = new RegExp(
+    `<Relationship\\b[^>]*Target="([^"]+)"[^>]*Id="${escapedId}"`,
+  );
+  const altMatch = relsXml.match(altPattern);
+  return altMatch?.[1];
+}
+
+/** パスを解決して ZIP 内の絶対パスにする（相対パス・ルート絶対パス両対応） */
+function resolveMediaPath(basePath: string, targetPath: string): string {
+  // ルート絶対パス (e.g. "/ppt/media/image1.png") の場合は先頭 "/" を除去して返す
+  if (targetPath.startsWith("/")) {
+    return targetPath.slice(1);
+  }
+
+  const dir = basePath.substring(0, basePath.lastIndexOf("/"));
+  const parts = dir.split("/");
+  for (const segment of targetPath.split("/")) {
+    if (segment === ".." && parts.length > 0) {
+      parts.pop();
+    } else if (segment !== "." && segment !== "") {
+      parts.push(segment);
+    }
+  }
+  return parts.join("/");
+}
+
+/** ファイル拡張子からMIMEタイプを推定する */
+function guessMimeType(filePath: string): string {
+  const ext = filePath.split(".").pop()?.toLowerCase();
+  switch (ext) {
+    case "png":
+      return "image/png";
+    case "jpg":
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "bmp":
+      return "image/bmp";
+    case "tiff":
+    case "tif":
+      return "image/tiff";
+    case "svg":
+      return "image/svg+xml";
+    case "emf":
+      return "image/x-emf";
+    case "wmf":
+      return "image/x-wmf";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+/** Uint8Array を Data URL に変換する */
+function toDataUrl(data: Uint8Array, contentType: string): string {
+  const base64 = Buffer.from(data).toString("base64");
+  return `data:${contentType};base64,${base64}`;
+}
+
+/** XML から名前属性を取得する（スライドマスター / レイアウトの名前） */
+function extractName(xml: string, tag: string): string {
+  const pattern = new RegExp(`<${tag}\\b[^>]*name="([^"]+)"`);
+  const match = xml.match(pattern);
+  return match?.[1] ?? "";
+}
+
+interface BackgroundImageInfo {
+  data: Uint8Array;
+  contentType: string;
+  dataUrl: string;
+}
+
+/** XML と rels から背景画像を抽出する共通処理 */
+async function extractBackgroundImage(
+  zip: JSZip,
+  xmlPath: string,
+  xml: string,
+): Promise<BackgroundImageInfo | undefined> {
+  const rId = findBackgroundBlipEmbed(xml);
+  if (!rId) return undefined;
+
+  // .rels ファイルのパスを算出
+  const dir = xmlPath.substring(0, xmlPath.lastIndexOf("/"));
+  const fileName = xmlPath.substring(xmlPath.lastIndexOf("/") + 1);
+  const relsPath = `${dir}/_rels/${fileName}.rels`;
+
+  const relsFile = zip.file(relsPath);
+  if (!relsFile) return undefined;
+
+  const relsXml = await relsFile.async("string");
+  const target = resolveRelationship(relsXml, rId);
+  if (!target) return undefined;
+
+  const mediaPath = resolveMediaPath(xmlPath, target);
+  const mediaFile = zip.file(mediaPath);
+  if (!mediaFile) return undefined;
+
+  const data = new Uint8Array(await mediaFile.async("arraybuffer"));
+  const contentType = guessMimeType(mediaPath);
+  const dataUrl = toDataUrl(data, contentType);
+
+  return { data, contentType, dataUrl };
+}
+
+async function extractSlideMasterBackgrounds(
+  zip: JSZip,
+): Promise<SlideMasterBackground[]> {
+  const results: SlideMasterBackground[] = [];
+  const masterFiles: string[] = [];
+
+  zip.forEach((path) => {
+    if (/^ppt\/slideMasters\/slideMaster\d+\.xml$/.test(path)) {
+      masterFiles.push(path);
+    }
+  });
+
+  masterFiles.sort();
+
+  for (const masterPath of masterFiles) {
+    const xml = await zip.file(masterPath)!.async("string");
+    const bgInfo = await extractBackgroundImage(zip, masterPath, xml);
+    if (!bgInfo) continue;
+
+    const masterName = extractName(xml, "p:cSld");
+
+    results.push({
+      masterName,
+      contentType: bgInfo.contentType,
+      data: bgInfo.data,
+      dataUrl: bgInfo.dataUrl,
+    });
+  }
+
+  return results;
+}
+
+async function extractSlideLayoutBackgrounds(
+  zip: JSZip,
+): Promise<SlideLayoutBackground[]> {
+  const results: SlideLayoutBackground[] = [];
+  const layoutFiles: string[] = [];
+
+  zip.forEach((path) => {
+    if (/^ppt\/slideLayouts\/slideLayout\d+\.xml$/.test(path)) {
+      layoutFiles.push(path);
+    }
+  });
+
+  layoutFiles.sort();
+
+  for (const layoutPath of layoutFiles) {
+    const xml = await zip.file(layoutPath)!.async("string");
+    const bgInfo = await extractBackgroundImage(zip, layoutPath, xml);
+    if (!bgInfo) continue;
+
+    const layoutName = extractName(xml, "p:cSld");
+
+    results.push({
+      layoutName,
+      contentType: bgInfo.contentType,
+      data: bgInfo.data,
+      dataUrl: bgInfo.dataUrl,
+    });
+  }
+
+  return results;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,6 +113,37 @@ export interface TemplateInfo {
   layouts: LayoutInfo[];
 }
 
+// === Slide Master Background ===
+
+export interface SlideMasterBackground {
+  /** スライドマスター名 */
+  masterName: string;
+  /** 背景画像のMIMEタイプ (e.g. "image/png", "image/jpeg") */
+  contentType: string;
+  /** 背景画像のバイナリデータ */
+  data: Uint8Array;
+  /** Data URL (Webview表示用) */
+  dataUrl: string;
+}
+
+export interface SlideLayoutBackground {
+  /** スライドレイアウト名 */
+  layoutName: string;
+  /** 背景画像のMIMEタイプ */
+  contentType: string;
+  /** 背景画像のバイナリデータ */
+  data: Uint8Array;
+  /** Data URL (Webview表示用) */
+  dataUrl: string;
+}
+
+export interface BackgroundExtractionResult {
+  /** スライドマスターの背景画像一覧 */
+  masters: SlideMasterBackground[];
+  /** スライドレイアウトの背景画像一覧（レイアウト固有の背景を持つもののみ） */
+  layouts: SlideLayoutBackground[];
+}
+
 // === Placeholder Mapping ===
 
 export interface PlaceholderAssignment {


### PR DESCRIPTION
close #13

## 概要

- JSZipを使ってPPTXテンプレートからスライドマスター・スライドレイアウトの背景画像を抽出する機能を追加
- 抽出した画像はBase64 Data URLとして返却し、Webviewプレビューでの背景表示に使用可能
- 図形・グラデーション構成の場合は抽出対象外（画像背景のみ対応）

## 変更内容

- `src/slide-master-extractor.ts` — 背景画像抽出のコアロジック
  - スライドマスターXMLから `<p:bg>` → `<a:blipFill>` → `<a:blip r:embed>` を解析
  - `.rels` ファイルからリレーションシップIDを解決してメディアファイルパスを特定
  - 相対パス・ルート絶対パス両対応のパス解決
  - MIMEタイプ推定、Data URL変換
- `src/types.ts` — `SlideMasterBackground`, `SlideLayoutBackground`, `BackgroundExtractionResult` 型を追加
- `src/index.ts` — 新モジュールと型をエクスポート
- `src/__tests__/slide-master-extractor.test.ts` — ユニットテスト13ケース

## テストプラン

- [x] ユニットテスト全139件通過
- [x] TypeScript型チェック通過
- [x] ESLint通過
- [x] Prettierフォーマットチェック通過
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)