### PR TITLE
refactor: テストファイルをソースファイルとコロケーション

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run format:check   # Prettier チェック
 単一テストファイルの実行:
 
 ```bash
-npx vitest run src/__tests__/parser.test.ts
+npx vitest run src/parser.test.ts
 ```
 
 ### VS Code 拡張

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -9,14 +9,14 @@ import {
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
-vi.mock("../parser.js", () => ({
+vi.mock("./parser.js", () => ({
   parseMarkdown: vi.fn(() => ({
     frontMatter: {},
     slides: [{ layout: undefined, content: [], notes: [], directives: [] }],
   })),
 }));
 
-vi.mock("../template-reader.js", () => ({
+vi.mock("./template-reader.js", () => ({
   readTemplate: vi.fn(() => ({
     layouts: [
       {
@@ -31,7 +31,7 @@ vi.mock("../template-reader.js", () => ({
   })),
 }));
 
-vi.mock("../placeholder-mapper.js", () => ({
+vi.mock("./placeholder-mapper.js", () => ({
   mapPresentation: vi.fn(() => [
     {
       layoutName: "Blank",
@@ -42,15 +42,15 @@ vi.mock("../placeholder-mapper.js", () => ({
   ]),
 }));
 
-vi.mock("../pptx-generator.js", () => ({
+vi.mock("./pptx-generator.js", () => ({
   generatePptx: vi.fn(() => new Uint8Array([0x50, 0x4b, 0x03, 0x04])),
 }));
 
-import { parseMarkdown } from "../parser.js";
-import { readTemplate } from "../template-reader.js";
-import { mapPresentation } from "../placeholder-mapper.js";
-import { generatePptx } from "../pptx-generator.js";
-import { buildAction, inspectAction, createProgram } from "../cli.js";
+import { parseMarkdown } from "./parser.js";
+import { readTemplate } from "./template-reader.js";
+import { mapPresentation } from "./placeholder-mapper.js";
+import { generatePptx } from "./pptx-generator.js";
+import { buildAction, inspectAction, createProgram } from "./cli.js";
 
 describe("CLI", () => {
   describe("createProgram", () => {

--- a/src/directives.test.ts
+++ b/src/directives.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseDirective, extractCommentContent } from "../directives.js";
+import { parseDirective, extractCommentContent } from "./directives.js";
 
 describe("parseDirective", () => {
   it("should parse local directive", () => {

--- a/src/front-matter.test.ts
+++ b/src/front-matter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractFrontMatter } from "../front-matter.js";
+import { extractFrontMatter } from "./front-matter.js";
 
 describe("extractFrontMatter", () => {
   it("should parse front matter with all keys", () => {

--- a/src/parser.test.ts
+++ b/src/parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseMarkdown } from "../parser.js";
+import { parseMarkdown } from "./parser.js";
 
 describe("parseMarkdown", () => {
   it("should parse a minimal document", () => {

--- a/src/placeholder-mapper.test.ts
+++ b/src/placeholder-mapper.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   mapSlideToPlaceholders,
   mapPresentation,
-} from "../placeholder-mapper.js";
+} from "./placeholder-mapper.js";
 import type {
   SlideData,
   LayoutInfo,
@@ -13,7 +13,7 @@ import type {
   ImageElement,
   TemplateInfo,
   ParseResult,
-} from "../types.js";
+} from "./types.js";
 
 // === ヘルパー ===
 

--- a/src/placeholder-utils.test.ts
+++ b/src/placeholder-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { toPlaceholderType, findLayout } from "../placeholder-utils.js";
-import type { TemplateInfo } from "../types.js";
+import { toPlaceholderType, findLayout } from "./placeholder-utils.js";
+import type { TemplateInfo } from "./types.js";
 
 describe("toPlaceholderType", () => {
   it("CENTER_TITLE (1) を title に変換する", () => {

--- a/src/pptx-generator.test.ts
+++ b/src/pptx-generator.test.ts
@@ -8,7 +8,7 @@ import type {
   ParagraphElement,
   ListElement,
   ImageElement,
-} from "../types.js";
+} from "./types.js";
 
 // === Mock Setup ===
 
@@ -146,7 +146,7 @@ vi.mock("python-pptx-wasm", () => ({
 }));
 
 // Import after mock
-import { generatePptx } from "../pptx-generator.js";
+import { generatePptx } from "./pptx-generator.js";
 
 // === Helpers ===
 

--- a/src/slide-master-extractor.test.ts
+++ b/src/slide-master-extractor.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import JSZip from "jszip";
-import { extractBackgrounds } from "../slide-master-extractor.js";
+import { extractBackgrounds } from "./slide-master-extractor.js";
 
 /** テスト用のPPTXバイナリを生成するヘルパー */
 async function createTestPptx(

--- a/src/slide-splitter.test.ts
+++ b/src/slide-splitter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import MarkdownIt from "markdown-it";
-import { splitTokensIntoSlides } from "../slide-splitter.js";
+import { splitTokensIntoSlides } from "./slide-splitter.js";
 
 const md = new MarkdownIt({ html: true });
 

--- a/src/token-converter.test.ts
+++ b/src/token-converter.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import MarkdownIt from "markdown-it";
-import { convertTokensToSlide } from "../token-converter.js";
+import { convertTokensToSlide } from "./token-converter.js";
 
 const md = new MarkdownIt({ html: true });
 md.enable("strikethrough");

--- a/vscode-extension/src/webview/preview-panel.test.ts
+++ b/vscode-extension/src/webview/preview-panel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildShellHtml } from "../slide-renderer";
+import { buildShellHtml } from "./slide-renderer";
 
 describe("buildShellHtml", () => {
   it("有効な HTML を返す", () => {

--- a/vscode-extension/src/webview/slide-renderer.test.ts
+++ b/vscode-extension/src/webview/slide-renderer.test.ts
@@ -3,7 +3,7 @@ import {
   buildSlideRenderData,
   resolveBackground,
   resolveContentImages,
-} from "../slide-renderer";
+} from "./slide-renderer";
 import type { SlideData, BackgroundExtractionResult } from "md-pptx";
 
 describe("buildSlideRenderData", () => {


### PR DESCRIPTION
## 概要

- テストファイルを `__tests__/` ディレクトリからテスト対象のソースファイルと同じディレクトリに移動
- コアライブラリ（`src/`）と VS Code 拡張（`vscode-extension/src/webview/`）の両方が対象
- インポートパスを `../` から `./` に修正
- CLAUDE.md のテストコマンド例を更新

## 変更内容

- `src/__tests__/*.test.ts` → `src/*.test.ts`（10ファイル）
- `vscode-extension/src/webview/__tests__/*.test.ts` → `vscode-extension/src/webview/*.test.ts`（2ファイル）
- `__tests__/` ディレクトリを削除

## テスト計画

- [x] コアライブラリのユニットテスト通過（13ファイル、159テスト）
- [x] VS Code 拡張のユニットテスト通過（2ファイル、20テスト）
- [x] ESLint チェック通過
- [x] Prettier フォーマットチェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)