### PR TITLE
chore: VS Code Marketplace 公開に向けた package.json 整備

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "md-pptx",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "md-pptx",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "md-pptx",
   "displayName": "md-pptx",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Markdown とテンプレート PPTX から編集可能な PowerPoint ファイルを生成するツール",
   "publisher": "hirokisakabe",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hirokisakabe/md-pptx.git"
+  },
   "type": "module",
   "main": "./dist/extension.cjs",
   "types": "./dist/index.d.ts",
@@ -16,14 +20,12 @@
   "bin": {
     "md-pptx": "./dist/cli.js"
   },
-  "files": [
-    "dist"
-  ],
   "engines": {
     "vscode": "^1.100.0"
   },
   "categories": [
-    "Other"
+    "Programming Languages",
+    "Formatters"
   ],
   "activationEvents": [
     "onLanguage:markdown"


### PR DESCRIPTION
close #38

## 概要

VS Code Marketplace への公開に必要な package.json の整備を行った。

- `version` を `0.0.0` → `0.1.0` に変更
- `repository` フィールドを追加
- `categories` を `["Other"]` → `["Programming Languages", "Formatters"]` に変更
- `files` フィールドを削除（`.vscodeignore` との競合を解消し、`vsce package` が成功するように）

## 確認事項

- `vsce package` でエラーなく `.vsix` が生成できることを確認済み
- `license` フィールド（`MIT`）は既に設定済み
- ルートに MIT LICENSE ファイルが存在することを確認済み
- `publisher`（`hirokisakabe`）は既に設定済み

## テスト計画

- [ ] `npm run lint` が通ること
- [ ] `npm run format:check` が通ること
- [ ] `vsce package` で `.vsix` が生成できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)