### PR TITLE
fix: release ワークフローのタグ存在チェックをリモート参照に変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,8 +36,8 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           VERSION="v$(node -p "require('./package.json').version")"
-          # タグが既に存在する場合はスキップ
-          if git rev-parse "$VERSION" >/dev/null 2>&1; then
+          # タグが既に存在する場合はスキップ（リモートをチェック）
+          if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "Tag $VERSION already exists, skipping"
             exit 0
           fi


### PR DESCRIPTION
close #60

## 概要

release ワークフローの「Create and push tag」ステップで、リモートに既に存在するタグを検出できず `git push` 時にエラーになる問題を修正。

## 変更内容

- `git rev-parse` (ローカルタグ参照) を `git ls-remote --exit-code --tags origin` (リモートタグ参照) に変更
- `actions/checkout@v4` がデフォルトでタグをフェッチしない環境でも正しくタグの存在を検出可能に

## Test plan

- [ ] release ワークフローが既存タグのバージョンで実行された場合、スキップされることを確認
- [ ] 新バージョンの場合、タグが正常に作成・プッシュされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)