### PR TITLE
fix: GITHUB_TOKEN による tag push で publish がトリガーされない問題を修正

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag name (e.g. v1.0.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -24,7 +30,8 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG="${{ inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "::error::Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,13 +33,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push tag
+        id: create-tag
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           VERSION="v$(node -p "require('./package.json').version")"
           # タグが既に存在する場合はスキップ（リモートをチェック）
           if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "Tag $VERSION already exists, skipping"
+            echo "tag-created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           git tag "$VERSION"
           git push origin "$VERSION"
+          echo "tag-created=true" >> "$GITHUB_OUTPUT"
+          echo "tag-name=$VERSION" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      tag-created: ${{ steps.create-tag.outputs.tag-created }}
+      tag-name: ${{ steps.create-tag.outputs.tag-name }}
+
+  publish:
+    needs: release
+    if: needs.release.outputs.tag-created == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.release.outputs.tag-name }}
+    secrets: inherit


### PR DESCRIPTION
close #65

## Summary

- `publish.yml` に `workflow_call` トリガーを追加し、再利用可能ワークフローとして呼び出せるようにした
- `release.yml` の tag 作成ステップにジョブ出力（`tag-created`, `tag-name`）を追加し、新規タグ作成時のみ `publish.yml` を `workflow_call` で呼び出す `publish` ジョブを追加
- `publish.yml` の version 検証ステップで `inputs.tag || github.ref_name` を参照するよう変更し、両トリガーに対応
- 手動 tag push でも publish が動作するよう `on: push: tags` トリガーは維持

## Test plan

- [ ] changeset 消費後の Version PR マージで tag 作成 → publish が一連の流れで実行されることを確認
- [ ] 既にタグが存在する場合は publish ジョブがスキップされることを確認
- [ ] 手動で tag を push した場合にも publish が動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)