### PR TITLE
feat: レイアウト未指定スライドのデフォルトレイアウト選択を改善

### DIFF
--- a/.changeset/improve-default-layout-selection.md
+++ b/.changeset/improve-default-layout-selection.md
@@ -1,0 +1,9 @@
+---
+"md-pptx": minor
+---
+
+レイアウト未指定スライドのデフォルトレイアウト選択を改善
+
+- スライドのコンテンツ構成（見出し・本文・画像）に応じて適切なレイアウトを自動選択するようにした
+- `toPlaceholderType` で rawType=7 (OBJECT/Content Placeholder) を "body" としてマッピングするようにした
+- Title Slide レイアウトで body がない場合、本文テキストを subtitle プレースホルダーに割り当てるようにした

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -225,9 +225,10 @@ describe("E2E: 生成PPTXの内容検証", () => {
 
     const zip = await JSZip.loadAsync(pptxData);
 
-    // スライド1: _layout: Title Slide → タイトルテキストが注入される
+    // スライド1: _layout: Title Slide → タイトルとサブタイトルが注入される
     const slide1 = await zip.file("ppt/slides/slide1.xml")!.async("string");
     expect(slide1).toContain("md-pptx サンプル");
+    expect(slide1).toContain("VS Code拡張の動作確認用");
 
     // スライド6: _layout: Title Slide → タイトルテキストが注入される
     const slide6 = await zip.file("ppt/slides/slide6.xml")!.async("string");

--- a/src/core/placeholder-mapper.test.ts
+++ b/src/core/placeholder-mapper.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   mapSlideToPlaceholders,
   mapPresentation,
+  selectDefaultLayout,
 } from "./placeholder-mapper.js";
 import type {
   SlideData,
@@ -175,6 +176,34 @@ describe("mapSlideToPlaceholders", () => {
       expect(subtitleAssignment!.placeholderIdx).toBe(0);
       expect(subtitleAssignment!.content).toHaveLength(1);
       expect(subtitleAssignment!.content[0].type).toBe("heading");
+
+      expect(result.unmappedContent).toHaveLength(0);
+    });
+
+    it("title+subtitleレイアウトでbodyがない場合、本文をsubtitleにマッピングする", () => {
+      const titleSlideLayout: LayoutInfo = {
+        name: "Title Slide",
+        placeholders: [
+          { idx: 0, type: "title", name: "Title 1" },
+          { idx: 1, type: "subtitle", name: "Subtitle 2" },
+        ],
+      };
+      const s = slide([heading(1, "タイトル"), paragraph("サブテキスト")]);
+      const result = mapSlideToPlaceholders(s, titleSlideLayout);
+
+      const titleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "title",
+      );
+      expect(titleAssignment).toBeDefined();
+      expect(titleAssignment!.content[0].type).toBe("heading");
+
+      const subtitleAssignment = result.assignments.find(
+        (a) => a.placeholderType === "subtitle",
+      );
+      expect(subtitleAssignment).toBeDefined();
+      expect(subtitleAssignment!.placeholderIdx).toBe(1);
+      expect(subtitleAssignment!.content).toHaveLength(1);
+      expect(subtitleAssignment!.content[0].type).toBe("paragraph");
 
       expect(result.unmappedContent).toHaveLength(0);
     });
@@ -356,7 +385,7 @@ describe("mapPresentation", () => {
     expect(results[0].unmappedContent).toHaveLength(2);
   });
 
-  it("layoutが未指定のスライドはBlankにフォールバックする", () => {
+  it("layoutが未指定で見出し+本文のスライドはTitle and Contentを自動選択する", () => {
     const parseResult: ParseResult = {
       frontMatter: {},
       slides: [slide([heading(1, "タイトル"), paragraph("本文")])],
@@ -365,7 +394,30 @@ describe("mapPresentation", () => {
     const results = mapPresentation(parseResult, templateInfo);
 
     expect(results).toHaveLength(1);
-    expect(results[0].fallbackToBlank).toBe(true);
+    expect(results[0].layoutName).toBe("Title and Content");
+    expect(results[0].fallbackToBlank).toBe(false);
+    expect(results[0].assignments).toHaveLength(2);
+
+    const titleAssignment = results[0].assignments.find(
+      (a) => a.placeholderType === "title",
+    );
+    expect(titleAssignment).toBeDefined();
+
+    const bodyAssignment = results[0].assignments.find(
+      (a) => a.placeholderType === "body",
+    );
+    expect(bodyAssignment).toBeDefined();
+  });
+
+  it("layoutが未指定で本文のみのスライドはBlankにフォールバックする", () => {
+    const parseResult: ParseResult = {
+      frontMatter: {},
+      slides: [slide([paragraph("本文のみ")])],
+    };
+
+    const results = mapPresentation(parseResult, templateInfo);
+
+    expect(results).toHaveLength(1);
     expect(results[0].layoutName).toBe("Blank");
   });
 
@@ -392,5 +444,95 @@ describe("mapPresentation", () => {
     );
     expect(bodyAssignment).toBeDefined();
     expect(bodyAssignment!.content).toHaveLength(1);
+  });
+});
+
+describe("selectDefaultLayout", () => {
+  const SECTION_HEADER_LAYOUT: LayoutInfo = {
+    name: "Section Header",
+    placeholders: [
+      { idx: 0, type: "title", name: "Title 1" },
+      { idx: 1, type: "body", name: "Text Placeholder 2" },
+    ],
+  };
+
+  const TITLE_SLIDE_LAYOUT: LayoutInfo = {
+    name: "Title Slide",
+    placeholders: [
+      { idx: 0, type: "title", name: "Title 1" },
+      { idx: 1, type: "subtitle", name: "Subtitle 2" },
+    ],
+  };
+
+  const templateInfo: TemplateInfo = {
+    layouts: [
+      TITLE_SLIDE_LAYOUT,
+      TITLE_AND_CONTENT_LAYOUT,
+      SECTION_HEADER_LAYOUT,
+      BLANK_LAYOUT,
+    ],
+  };
+
+  it("見出し+本文 → Title and Content を選択する", () => {
+    const s = slide([heading(1, "タイトル"), paragraph("本文")]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Title and Content");
+  });
+
+  it("見出し+リスト → Title and Content を選択する", () => {
+    const s = slide([heading(2, "タイトル"), list(["項目1", "項目2"])]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Title and Content");
+  });
+
+  it("見出しのみ → Section Header を選択する", () => {
+    const s = slide([heading(1, "セクション")]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Section Header");
+  });
+
+  it("Section Headerがない場合、見出しのみ → Title Slide を選択する", () => {
+    const templateWithoutSectionHeader: TemplateInfo = {
+      layouts: [TITLE_SLIDE_LAYOUT, TITLE_AND_CONTENT_LAYOUT, BLANK_LAYOUT],
+    };
+    const s = slide([heading(1, "タイトル")]);
+    const layout = selectDefaultLayout(s, templateWithoutSectionHeader);
+    expect(layout.name).toBe("Title Slide");
+  });
+
+  it("本文のみ → Blank を選択する", () => {
+    const s = slide([paragraph("本文のみ")]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Blank");
+  });
+
+  it("コンテンツなし → Blank を選択する", () => {
+    const s = slide([]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Blank");
+  });
+
+  it("見出し+画像 → Title and Content を選択する", () => {
+    const s = slide([heading(1, "タイトル"), image("photo.png")]);
+    const layout = selectDefaultLayout(s, templateInfo);
+    expect(layout.name).toBe("Title and Content");
+  });
+
+  it("名前で見つからない場合、プレースホルダー構成でマッチする", () => {
+    const customTemplate: TemplateInfo = {
+      layouts: [
+        {
+          name: "カスタムレイアウト",
+          placeholders: [
+            { idx: 0, type: "title", name: "Title" },
+            { idx: 1, type: "body", name: "Body" },
+          ],
+        },
+        BLANK_LAYOUT,
+      ],
+    };
+    const s = slide([heading(1, "タイトル"), paragraph("本文")]);
+    const layout = selectDefaultLayout(s, customTemplate);
+    expect(layout.name).toBe("カスタムレイアウト");
   });
 });

--- a/src/core/placeholder-mapper.ts
+++ b/src/core/placeholder-mapper.ts
@@ -11,6 +11,84 @@ import type {
 } from "./types.js";
 import { findLayout } from "./placeholder-utils.js";
 
+interface ContentProfile {
+  hasHeading: boolean;
+  hasBody: boolean;
+  hasImage: boolean;
+}
+
+function analyzeContent(content: ContentElement[]): ContentProfile {
+  let hasHeading = false;
+  let hasBody = false;
+  let hasImage = false;
+
+  for (const element of content) {
+    if (
+      element.type === "heading" &&
+      (element.level === 1 || element.level === 2)
+    ) {
+      hasHeading = true;
+    } else if (element.type === "image") {
+      hasImage = true;
+    } else {
+      hasBody = true;
+    }
+  }
+
+  return { hasHeading, hasBody, hasImage };
+}
+
+function layoutHasPlaceholder(
+  layout: LayoutInfo,
+  type: PlaceholderType,
+): boolean {
+  return layout.placeholders.some((p) => p.type === type);
+}
+
+export function selectDefaultLayout(
+  slide: SlideData,
+  templateInfo: TemplateInfo,
+): LayoutInfo {
+  const profile = analyzeContent(slide.content);
+  const blankLayout =
+    findLayout(templateInfo, "Blank") ??
+    ({ name: "Blank", placeholders: [] } as LayoutInfo);
+
+  if (!profile.hasHeading && !profile.hasImage) {
+    return blankLayout;
+  }
+
+  if (profile.hasHeading && (profile.hasBody || profile.hasImage)) {
+    // 見出し + 本文/画像: "Title and Content" を優先
+    const byName = findLayout(templateInfo, "Title and Content");
+    if (byName) return byName;
+
+    // 名前で見つからない場合、title + body を持つレイアウトを探す
+    const byPlaceholder = templateInfo.layouts.find(
+      (l) =>
+        layoutHasPlaceholder(l, "title") && layoutHasPlaceholder(l, "body"),
+    );
+    if (byPlaceholder) return byPlaceholder;
+  }
+
+  if (profile.hasHeading && !profile.hasBody && !profile.hasImage) {
+    // 見出しのみ: "Section Header" → "Title Slide" の順
+    const sectionHeader = findLayout(templateInfo, "Section Header");
+    if (sectionHeader) return sectionHeader;
+
+    const titleSlide = findLayout(templateInfo, "Title Slide");
+    if (titleSlide) return titleSlide;
+
+    // 名前で見つからない場合、title を持つレイアウトを探す
+    const byPlaceholder = templateInfo.layouts.find((l) =>
+      layoutHasPlaceholder(l, "title"),
+    );
+    if (byPlaceholder) return byPlaceholder;
+  }
+
+  return blankLayout;
+}
+
 const BLANK_LAYOUT: LayoutInfo = { name: "Blank", placeholders: [] };
 
 function findPlaceholder(
@@ -65,6 +143,8 @@ export function mapSlideToPlaceholders(
     } else {
       if (bodyPh) {
         bodyContent.push(element);
+      } else if (subtitlePh && titlePh && titleAssigned) {
+        subtitleContent.push(element);
       } else {
         unmappedContent.push(element);
       }
@@ -122,10 +202,13 @@ export function mapPresentation(
 ): SlideMappingResult[] {
   return parseResult.slides.map((slide: SlideData) => {
     const layoutName = slide.layout;
-    const layout = layoutName
-      ? findLayout(templateInfo, layoutName)
-      : undefined;
 
+    if (!layoutName) {
+      const defaultLayout = selectDefaultLayout(slide, templateInfo);
+      return mapSlideToPlaceholders(slide, defaultLayout);
+    }
+
+    const layout = findLayout(templateInfo, layoutName);
     if (!layout) {
       const blankLayout = findLayout(templateInfo, "Blank") ?? BLANK_LAYOUT;
       return mapSlideToPlaceholders(slide, blankLayout);

--- a/src/core/placeholder-utils.test.ts
+++ b/src/core/placeholder-utils.test.ts
@@ -15,6 +15,10 @@ describe("toPlaceholderType", () => {
     expect(toPlaceholderType(2)).toBe("body");
   });
 
+  it("OBJECT (7) を body に変換する", () => {
+    expect(toPlaceholderType(7)).toBe("body");
+  });
+
   it("SUBTITLE (4) を subtitle に変換する", () => {
     expect(toPlaceholderType(4)).toBe("subtitle");
   });

--- a/src/core/placeholder-utils.ts
+++ b/src/core/placeholder-utils.ts
@@ -15,6 +15,7 @@ export function toPlaceholderType(rawType: number): PlaceholderType {
     case 3: // CENTER_TITLE
       return "title";
     case 2: // BODY
+    case 7: // OBJECT (Content Placeholder)
       return "body";
     case 4: // SUBTITLE
       return "subtitle";


### PR DESCRIPTION
close #64

## Summary

- レイアウトディレクティブが未指定のスライドに対して、コンテンツ構成（見出し・本文・画像の有無）に基づき適切なレイアウトを自動選択するようにした
- `toPlaceholderType` で rawType=7 (OBJECT/Content Placeholder) を "body" としてマッピングするよう修正し、"Title and Content" レイアウトの Content Placeholder が正しく認識されるようにした
- Title Slide レイアウトで body プレースホルダーがない場合、本文テキストを subtitle プレースホルダーに割り当てるようにした

## レイアウト自動選択ロジック

| コンテンツ構成 | 選択されるレイアウト |
|---|---|
| 見出し + 本文/リスト | "Title and Content" |
| 見出し + 画像 | "Title and Content" |
| 見出しのみ | "Section Header" → "Title Slide" |
| 本文のみ / コンテンツなし | "Blank"（現状維持） |

名前でマッチしない場合はプレースホルダー構成によるフォールバックマッチを行います。

## 変更ファイル

- `src/core/placeholder-utils.ts` — rawType=7 を "body" に追加
- `src/core/placeholder-mapper.ts` — `selectDefaultLayout` 関数追加、subtitle への本文割り当て
- `src/core/placeholder-mapper.test.ts` — テスト追加・更新
- `src/core/placeholder-utils.test.ts` — rawType=7 のテスト追加
- `e2e/e2e.test.ts` — sample.md の subtitle テキスト検証を追加

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm test` 全172テスト通過
- [x] `npm run test:e2e` 全11テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)