### PR TITLE
test: sample.md の全要素を検証する E2E テストを追加

### DIFF
--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -39,9 +39,9 @@ function assertValidPptx(data: Uint8Array) {
   expect(data[1]).toBe(0x4b);
 }
 
-/** PPTXバイナリからスライド数を取得するヘルパー */
-async function countSlides(data: Uint8Array): Promise<number> {
-  const zip = await JSZip.loadAsync(data);
+/** PPTXバイナリまたはJSZipインスタンスからスライド数を取得するヘルパー */
+async function countSlides(data: Uint8Array | JSZip): Promise<number> {
+  const zip = data instanceof JSZip ? data : await JSZip.loadAsync(data);
   let count = 0;
   zip.forEach((relativePath) => {
     if (/^ppt\/slides\/slide\d+\.xml$/.test(relativePath)) {
@@ -214,7 +214,7 @@ describe("E2E: 生成PPTXの内容検証", () => {
     expect(slideXml).toContain("Title 1");
   });
 
-  it("sample.mdからPPTXを生成するとレイアウト指定スライドにテキストが含まれる", async () => {
+  it("sample.mdからPPTXを生成すると全スライド・全要素が含まれる", async () => {
     const md = readFileSync(
       join(__dirname, "..", "sample", "sample.md"),
       "utf-8",
@@ -225,14 +225,72 @@ describe("E2E: 生成PPTXの内容検証", () => {
 
     const zip = await JSZip.loadAsync(pptxData);
 
-    // スライド1: _layout: Title Slide → タイトルとサブタイトルが注入される
+    // スライド数: 6枚
+    const slideCount = await countSlides(zip);
+    expect(slideCount).toBe(6);
+
+    // --- スライド1: Title Slide レイアウト ---
     const slide1 = await zip.file("ppt/slides/slide1.xml")!.async("string");
     expect(slide1).toContain("md-pptx サンプル");
     expect(slide1).toContain("VS Code拡張の動作確認用");
 
-    // スライド6: _layout: Title Slide → タイトルテキストが注入される
+    // --- スライド2: 概要（箇条書き + 書式 + プレゼンターノート） ---
+    const slide2 = await zip.file("ppt/slides/slide2.xml")!.async("string");
+    expect(slide2).toContain("概要");
+    expect(slide2).toContain("MarkdownからPPTXを生成するツール");
+    // 太字テキスト
+    expect(slide2).toContain("テンプレートPPTX");
+    // 斜体テキスト
+    expect(slide2).toContain("編集可能な");
+    // PPTXを出力
+    expect(slide2).toContain("PPTXを出力");
+    // プレゼンターノート（スライド2に紐づくnotesSlideを検証）
+    const slide2Rels = zip.file("ppt/slides/_rels/slide2.xml.rels");
+    expect(slide2Rels).not.toBeNull();
+    const slide2RelsXml = await slide2Rels!.async("string");
+    const notesMatch = slide2RelsXml.match(
+      /Target="(\.\.\/notesSlides\/notesSlide\d+\.xml)"/,
+    );
+    expect(notesMatch).not.toBeNull();
+    const notesPath = notesMatch![1].replace("../", "ppt/");
+    const notesFile = zip.file(notesPath);
+    expect(notesFile).not.toBeNull();
+    const notesXml = await notesFile!.async("string");
+    expect(notesXml).toContain("ここがプレゼンターノートになります");
+
+    // --- スライド3: テキスト書式のサンプル ---
+    const slide3 = await zip.file("ppt/slides/slide3.xml")!.async("string");
+    expect(slide3).toContain("テキスト書式のサンプル");
+    // 各書式のテキストが含まれる
+    expect(slide3).toContain("通常テキスト");
+    expect(slide3).toContain("太字テキスト");
+    expect(slide3).toContain("斜体テキスト");
+    expect(slide3).toContain("コード");
+    expect(slide3).toContain("取り消し線");
+    // リンクテキスト
+    expect(slide3).toContain("リンクのサンプル");
+
+    // --- スライド4: リストのサンプル（ネスト付き箇条書き） ---
+    const slide4 = await zip.file("ppt/slides/slide4.xml")!.async("string");
+    expect(slide4).toContain("リストのサンプル");
+    expect(slide4).toContain("箇条書き項目1");
+    expect(slide4).toContain("箇条書き項目2");
+    expect(slide4).toContain("ネストされた項目");
+    expect(slide4).toContain("さらにネスト");
+    expect(slide4).toContain("箇条書き項目3");
+
+    // --- スライド5: 番号付きリスト ---
+    const slide5 = await zip.file("ppt/slides/slide5.xml")!.async("string");
+    expect(slide5).toContain("番号付きリスト");
+    expect(slide5).toContain("最初の項目");
+    expect(slide5).toContain("二番目の項目");
+    expect(slide5).toContain("三番目の項目");
+
+    // --- スライド6: Title Slide レイアウト（締めスライド） ---
     const slide6 = await zip.file("ppt/slides/slide6.xml")!.async("string");
     expect(slide6).toContain("ご清聴ありがとうございました");
+    // メールリンクテキスト
+    expect(slide6).toContain("info@example.com");
   });
 
   it("生成PPTXをファイルに保存して再読み込みできる", () => {


### PR DESCRIPTION
## Summary

- sample.md から生成される PPTX の E2E テストを拡充し、全6スライドの全要素を網羅的に検証するようにした
- 既存テストはスライド1とスライド6のテキストのみ検証していたが、以下を追加:
  - スライド数（6枚）の検証
  - スライド2: 見出し、箇条書き、太字・斜体テキスト、プレゼンターノート（slide2.xml.rels から正確に紐づくノートファイルを特定）
  - スライド3: 通常テキスト、太字、斜体、コード、取り消し線、リンク
  - スライド4: ネスト付き箇条書きリスト
  - スライド5: 番号付きリスト
  - スライド6: メールリンク
- `countSlides` ヘルパーを `JSZip` インスタンスも受け取れるように拡張

## Test plan

- [x] `npm run test:e2e` — 全11テスト通過
- [x] `eslint` / `prettier` チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)