### PR TITLE
fix: vsce publish の extension エントリポイント解決エラーを修正

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -6,7 +6,7 @@ const watch = process.argv.includes("--watch");
 const buildOptions = {
   entryPoints: ["src/extension/extension.ts"],
   bundle: true,
-  outfile: "dist/extension.mjs",
+  outfile: "dist/extension.js",
   external: ["vscode", "pyodide"],
   format: "esm",
   platform: "node",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/hirokisakabe/md-pptx.git"
   },
   "type": "module",
-  "main": "./dist/extension.mjs",
+  "main": "./dist/extension.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- `vsce publish` が `.mjs` 拡張子を正しく解決できず、`extension/dist/extension.mjs.js` というパスを探してしまい publish が失敗していた問題を修正
- esbuild の出力ファイルを `dist/extension.mjs` → `dist/extension.js` に変更し、`package.json` の `main` フィールドも合わせて更新
- `"type": "module"` 設定により `.js` ファイルも ESM として扱われるため、動作に影響なし

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run test` 通過（172 tests）
- [x] `npx vsce package` で `.vsix` ファイルが正常に生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)