### PR TITLE
fix: publish ワークフローを冪等にする

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,21 @@ jobs:
       - name: Build Extension
         run: npm run build:extension
 
+      - name: Check if version is already published
+        id: check-published
+        run: |
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          PUBLISHED_VERSION="$(npx vsce show hirokisakabe.md-pptx --json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).versions[0].version" 2>/dev/null || echo "")"
+          if [ "$PKG_VERSION" = "$PUBLISHED_VERSION" ]; then
+            echo "Version $PKG_VERSION is already published, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Publishing version $PKG_VERSION (current published: ${PUBLISHED_VERSION:-none})"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to VS Code Marketplace
+        if: steps.check-published.outputs.skip != 'true'
         run: npx vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,24 +37,23 @@ jobs:
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           VERSION="v$(node -p "require('./package.json').version")"
-          # タグが既に存在する場合はスキップ（リモートをチェック）
           if git ls-remote --exit-code --tags origin "refs/tags/$VERSION" >/dev/null 2>&1; then
-            echo "Tag $VERSION already exists, skipping"
-            echo "tag-created=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "Tag $VERSION already exists, skipping tag creation"
+            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            git tag "$VERSION"
+            git push origin "$VERSION"
+            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
           fi
-          git tag "$VERSION"
-          git push origin "$VERSION"
-          echo "tag-created=true" >> "$GITHUB_OUTPUT"
           echo "tag-name=$VERSION" >> "$GITHUB_OUTPUT"
 
     outputs:
-      tag-created: ${{ steps.create-tag.outputs.tag-created }}
+      tag-exists: ${{ steps.create-tag.outputs.tag-exists }}
       tag-name: ${{ steps.create-tag.outputs.tag-name }}
 
   publish:
     needs: release
-    if: needs.release.outputs.tag-created == 'true'
+    if: needs.release.outputs.tag-name != ''
     uses: ./.github/workflows/publish.yml
     with:
       tag: ${{ needs.release.outputs.tag-name }}


### PR DESCRIPTION
## Summary
- publish 失敗後にワークフローを再実行しても、タグが既に存在するため publish ジョブがスキップされリカバリできない問題を修正
- `release.yml`: タグ既存時も `tag-name` を出力し publish ジョブを実行可能にする
- `publish.yml`: Marketplace に同バージョンが公開済みならスキップするガードを追加し、通常 push での不要な失敗を防止

## Test plan
- [ ] changeset なしの状態で main に push し、タグ作成 + publish が正常に動作することを確認
- [ ] publish 失敗をシミュレートし、ワークフロー再実行で publish がリトライされることを確認
- [ ] 既に公開済みのバージョンで再実行した場合、publish がスキップされ成功扱いになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)