### PR TITLE
feat: Build PPTX コマンドで出力先ディレクトリを選択可能にする

### DIFF
--- a/.changeset/download-directory-selection.md
+++ b/.changeset/download-directory-selection.md
@@ -1,0 +1,5 @@
+---
+"md-pptx": minor
+---
+
+VS Code 拡張: Build PPTX コマンドで出力先ディレクトリを選択可能にした

--- a/package.json
+++ b/package.json
@@ -41,6 +41,16 @@
         "title": "md-pptx: Preview"
       }
     ],
+    "configuration": {
+      "title": "md-pptx",
+      "properties": {
+        "md-pptx.defaultOutputDirectory": {
+          "type": "string",
+          "default": "",
+          "description": "PPTX ファイルのデフォルト出力先ディレクトリ。空の場合は Markdown ファイルと同じディレクトリが使用されます。"
+        }
+      }
+    },
     "menus": {
       "commandPalette": [
         {

--- a/src/extension/commands/build.ts
+++ b/src/extension/commands/build.ts
@@ -85,8 +85,38 @@ async function buildPptx(document: vscode.TextDocument): Promise<void> {
   });
 
   const parsed = path.parse(mdPath);
-  const outputPath = path.join(parsed.dir, parsed.name + ".pptx");
+  const defaultFileName = parsed.name + ".pptx";
+
+  const config = vscode.workspace.getConfiguration("md-pptx");
+  const defaultOutputDirectory = config.get<string>("defaultOutputDirectory");
+
+  const defaultDir = defaultOutputDirectory
+    ? vscode.Uri.file(path.resolve(parsed.dir, defaultOutputDirectory))
+    : vscode.Uri.file(parsed.dir);
+
+  const saveUri = await vscode.window.showSaveDialog({
+    defaultUri: vscode.Uri.joinPath(defaultDir, defaultFileName),
+    filters: {
+      PowerPoint: ["pptx"],
+    },
+  });
+
+  if (!saveUri) {
+    return;
+  }
+
+  const outputPath = saveUri.fsPath;
   fs.writeFileSync(outputPath, pptxData);
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+  const configTarget = workspaceFolder
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
+  await config.update(
+    "defaultOutputDirectory",
+    path.dirname(outputPath),
+    configTarget,
+  );
 
   vscode.window.showInformationMessage(
     `PPTX を生成しました: ${path.basename(outputPath)}`,


### PR DESCRIPTION
close #75

## 概要
- Build PPTX コマンド実行時に `vscode.window.showSaveDialog` で保存先を選択できるようにした
- 前回の保存先をワークスペース設定 `md-pptx.defaultOutputDirectory` として記憶する
- デフォルトの保存先は Markdown ファイルと同じディレクトリ（現状の挙動を維持）

## 変更内容
- `src/extension/commands/build.ts`: 出力パスのハードコードを `showSaveDialog` に置き換え、設定の読み書きを追加
- `package.json`: `contributes.configuration` に `md-pptx.defaultOutputDirectory` 設定を追加
- changeset を追加（minor）

## テスト計画
- [ ] Build PPTX コマンド実行時に保存先ダイアログが表示されること
- [ ] ダイアログでキャンセルした場合、ファイルが生成されないこと
- [ ] 保存先を選択した場合、選択したディレクトリに PPTX が生成されること
- [ ] 次回実行時に前回の保存先がデフォルトとして表示されること
- [ ] ワークスペース未オープン時でも正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)