### PR TITLE
feat: エディタタイトルバーにプレビュー起動アイコンを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
       },
       {
         "command": "md-pptx.preview",
-        "title": "md-pptx: Preview"
+        "title": "md-pptx: Preview",
+        "icon": {
+          "light": "images/icon.png",
+          "dark": "images/icon.png"
+        }
       }
     ],
     "configuration": {
@@ -61,6 +65,13 @@
         {
           "command": "md-pptx.preview",
           "when": "editorLangId == markdown"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "md-pptx.preview",
+          "when": "editorLangId == markdown",
+          "group": "navigation"
         }
       ]
     }


### PR DESCRIPTION
close #49

## 概要

- Markdown ファイルを開いているとき、エディタ右上のタイトルバーにプレビュー起動用のアイコンボタンを表示するようにした
- アイコンにはリポジトリの `images/icon.png` を使用
- `editorLangId == markdown` の条件で Markdown ファイルのときのみ表示

## 変更内容

- `package.json` の `contributes.commands` に `icon` フィールドを追加
- `contributes.menus` に `editor/title` メニューを追加

## テスト計画

- [ ] Markdown ファイルを開き、エディタ右上にアイコンが表示されることを確認
- [ ] アイコンをクリックしてプレビューが起動することを確認
- [ ] Markdown 以外のファイルではアイコンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)