### PR TITLE
fix: README.md のバッジ画像を SVG から PNG に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # md-pptx
 
-[![Version](https://vsmarketplacebadges.dev/version/hirokisakabe.md-pptx.svg)](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.md-pptx)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Version](https://vsmarketplacebadges.dev/version/hirokisakabe.md-pptx.png)](https://marketplace.visualstudio.com/items?itemName=hirokisakabe.md-pptx)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.png)](https://opensource.org/licenses/MIT)
 
 Markdown から編集可能な PowerPoint ファイルを生成する VS Code 拡張です。
 


### PR DESCRIPTION
## 概要

- VS Code Marketplace の `vsce publish` が README.md 内の SVG 画像を拒否するため、バッジ URL の拡張子を `.svg` から `.png` に変更
- 対象: Version バッジ (`vsmarketplacebadges.dev`) と License バッジ (`img.shields.io`)

## テスト計画

- [ ] CI が通ることを確認
- [ ] Marketplace への publish が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)