### PR TITLE
fix: .vscodeignore に fast-xml-builder と path-expression-matcher を追加

### DIFF
--- a/.changeset/fix-missing-vscodeignore-entries.md
+++ b/.changeset/fix-missing-vscodeignore-entries.md
@@ -1,0 +1,5 @@
+---
+"md-pptx": patch
+---
+
+fix: .vscodeignore に fast-xml-builder と path-expression-matcher を追加

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,9 +10,11 @@ node_modules/**
 !node_modules/python-pptx-wasm/**
 !node_modules/pptx-glimpse/**
 !node_modules/@resvg/**
+!node_modules/fast-xml-builder/**
 !node_modules/fast-xml-parser/**
 !node_modules/fflate/**
 !node_modules/opentype.js/**
+!node_modules/path-expression-matcher/**
 !node_modules/strnum/**
 .eslintrc*
 eslint.config.*


### PR DESCRIPTION
close #94

## 概要

- `.vscodeignore` に `!node_modules/fast-xml-builder/**` と `!node_modules/path-expression-matcher/**` を追加
- `fast-xml-parser` v5 の実行時依存がVSIXパッケージに含まれておらず、VS Code 拡張のアクティベーション時にモジュール解決エラーが発生していた問題を修正

## 背景

`pptx-glimpse` → `fast-xml-parser` v5.5.9 は以下の依存を持つ:
- `fast-xml-builder` ^1.1.4
- `path-expression-matcher` ^1.2.0
- `strnum` ^2.2.2

`strnum` は既に `.vscodeignore` で許可済みだったが、`fast-xml-builder` と `path-expression-matcher` が欠落していた。

## テスト計画

- [ ] VSIX パッケージをビルドし、`fast-xml-builder` と `path-expression-matcher` が含まれていることを確認
- [ ] VS Code で拡張をインストールし、アクティベーションが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)