### PR TITLE
fix: pptx-glimpse を esbuild の external から外してバンドルに含める

### DIFF
--- a/.changeset/remove-pptx-glimpse-external.md
+++ b/.changeset/remove-pptx-glimpse-external.md
@@ -1,0 +1,5 @@
+---
+"md-pptx": patch
+---
+
+pptx-glimpse を esbuild の external から外してバンドルに含める

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,14 +8,6 @@ sample/**
 node_modules/**
 !node_modules/pyodide/**
 !node_modules/python-pptx-wasm/**
-!node_modules/pptx-glimpse/**
-!node_modules/@resvg/**
-!node_modules/fast-xml-builder/**
-!node_modules/fast-xml-parser/**
-!node_modules/fflate/**
-!node_modules/opentype.js/**
-!node_modules/path-expression-matcher/**
-!node_modules/strnum/**
 .eslintrc*
 eslint.config.*
 tsconfig.json

--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -7,7 +7,7 @@ const buildOptions = {
   entryPoints: ["src/extension/extension.ts"],
   bundle: true,
   outfile: "dist/extension.js",
-  external: ["vscode", "pyodide", "pptx-glimpse"],
+  external: ["vscode", "pyodide"],
   format: "esm",
   platform: "node",
   target: "node22",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^14.0.3",
         "jszip": "^3.10.1",
         "markdown-it": "^14.1.1",
-        "pptx-glimpse": "^0.6.1",
+        "pptx-glimpse": "^0.7.0",
         "pyodide": "^0.28.3",
         "python-pptx-wasm": "^0.0.1"
       },
@@ -1236,217 +1236,11 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@resvg/resvg-js": {
+    "node_modules/@resvg/resvg-wasm": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
-      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-wasm/-/resvg-wasm-2.6.2.tgz",
+      "integrity": "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw==",
       "license": "MPL-2.0",
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
-        "@resvg/resvg-js-android-arm64": "2.6.2",
-        "@resvg/resvg-js-darwin-arm64": "2.6.2",
-        "@resvg/resvg-js-darwin-x64": "2.6.2",
-        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
-        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
-        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
-        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
-        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
-        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
-        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
-        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
-      }
-    },
-    "node_modules/@resvg/resvg-js-android-arm-eabi": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
-      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-android-arm64": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
-      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-darwin-arm64": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
-      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-darwin-x64": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
-      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
-      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
-      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
-      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
-      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-linux-x64-musl": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
-      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
-      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
-      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
-      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "engines": {
         "node": ">= 10"
       }
@@ -4425,12 +4219,12 @@
       }
     },
     "node_modules/pptx-glimpse": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/pptx-glimpse/-/pptx-glimpse-0.6.1.tgz",
-      "integrity": "sha512-9JAexWkN+G4YyiL7Nehp8uuldN5wQMp7oDlKfYzd7HHgF59lBhclRZEYVDF+a0vhfKsfjattJNc1DhcWCFl7Gw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/pptx-glimpse/-/pptx-glimpse-0.7.0.tgz",
+      "integrity": "sha512-VjMVUWyjbMIpug+pHkHHbgcDBrNEeZ2W+1LIUDjfqrbwI815jSkZ7/ScUH4/HQfGLLy7yJs+p02/WGxX2Uq0sQ==",
       "license": "MIT",
       "dependencies": {
-        "@resvg/resvg-js": "^2.6.2",
+        "@resvg/resvg-wasm": "^2.6.2",
         "fast-xml-parser": "^5.3.6",
         "fflate": "^0.8.2",
         "opentype.js": "^1.3.4"

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "commander": "^14.0.3",
     "jszip": "^3.10.1",
     "markdown-it": "^14.1.1",
-    "pptx-glimpse": "^0.6.1",
+    "pptx-glimpse": "^0.7.0",
     "pyodide": "^0.28.3",
     "python-pptx-wasm": "^0.0.1"
   },


### PR DESCRIPTION
close #97

## 概要

pptx-glimpse v0.7.0 で `@resvg/resvg-js` → `@resvg/resvg-wasm` への移行が完了し、ネイティブアドオン依存がなくなったため、esbuild の `external` から `pptx-glimpse` を外してバンドルに含める。

## 変更内容

- `pptx-glimpse` を `^0.6.1` → `^0.7.0` にアップデート
- `esbuild.mjs` の `external` から `pptx-glimpse` を削除
- `.vscodeignore` から pptx-glimpse 関連のホワイトリストエントリ（8件）を削除

## 効果

- `.vscodeignore` でのホワイトリスト手動管理が不要になり、#95 のような依存漏れが発生しなくなる

## テスト計画

- [x] `npm run typecheck` 成功
- [x] `npm run lint` 成功
- [x] `npm run format:check` 成功
- [x] `npm test` 成功
- [x] `node esbuild.mjs` ビルド成功
- [ ] CI 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)