### PR TITLE
feat: typescript-eslint の型チェック付きルールを有効化

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,8 +4,38 @@ import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   eslintConfigPrettier,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  {
+    // tsconfig.json に含まれない設定ファイル・テストは型チェック対象外
+    files: [
+      "eslint.config.js",
+      "tsup.config.ts",
+      "vitest.config.ts",
+      "vitest.config.*.ts",
+      "e2e/**/*.ts",
+      "vrt/**/*.ts",
+    ],
+    ...tseslint.configs.disableTypeChecked,
+  },
+  {
+    // python-pptx-wasm は型定義を提供しないため unsafe ルールを緩和
+    files: ["src/core/pptx-generator.ts", "src/core/pptx-generator.test.ts"],
+    rules: {
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-call": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
+    },
+  },
   {
     ignores: ["dist/", "node_modules/", "esbuild.mjs"],
   },

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -93,7 +93,7 @@ describe("CLI", () => {
       program.parse(["node", "md-pptx", "inspect", templatePath]);
 
       expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
-      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(output).toContain("レイアウト数: 2");
 
       consoleSpy.mockRestore();
@@ -197,7 +197,7 @@ describe("CLI", () => {
 
       expect(readTemplate).toHaveBeenCalledWith(expect.any(Uint8Array));
 
-      const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+      const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(output).toContain("レイアウト数: 2");
       expect(output).toContain("[Title Slide]");
       expect(output).toContain("idx: 0, type: title, name: Title 1");

--- a/src/core/pptx-generator.ts
+++ b/src/core/pptx-generator.ts
@@ -91,7 +91,7 @@ export function generatePptx(
       }
     }
 
-    return prs.save() as Uint8Array;
+    return prs.save();
   } finally {
     prs.end();
   }

--- a/src/extension/pyodide-loader.ts
+++ b/src/extension/pyodide-loader.ts
@@ -136,7 +136,7 @@ function extractTarGz(buffer: Buffer, destDir: string): Promise<void> {
         extractTar(tarData, destDir);
         resolve();
       } catch (e) {
-        reject(e);
+        reject(e instanceof Error ? e : new Error(String(e)));
       }
     });
   });


### PR DESCRIPTION
## Summary
- typescript-eslint の `recommended` を `recommendedTypeChecked` に変更し、型情報を活用した lint ルールを有効化
- `projectService` を設定し、tsconfig.json の型情報を ESLint に連携
- tsconfig に含まれない設定ファイル・テスト（eslint.config.js, tsup.config.ts, vitest.config.*.ts, e2e/, vrt/）は `disableTypeChecked` を適用
- python-pptx-wasm は型定義が不完全なため、pptx-generator 関連ファイルでは `no-unsafe-*` ルールを緩和
- 検出されたエラーを修正:
  - `pptx-generator.ts`: 不要な型アサーション `as Uint8Array` を削除
  - `pyodide-loader.ts`: `reject(e)` を `reject(e instanceof Error ? e : new Error(String(e)))` に修正
  - `cli.test.ts`: `c[0]` を `String(c[0])` に変更して `no-unsafe-return` を解消

## Test plan
- [x] `npm run lint` が成功すること
- [x] `npm run typecheck` が成功すること
- [x] `npm run format:check` が成功すること
- [ ] CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)