### PR TITLE
refactor: VRT フィクスチャの自動検出に置き換え

### DIFF
--- a/vrt/libreoffice/generate_fixtures.ts
+++ b/vrt/libreoffice/generate_fixtures.ts
@@ -4,8 +4,14 @@
  * Usage:
  *   npx tsx vrt/libreoffice/generate_fixtures.ts
  */
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
-import { join, dirname } from "node:path";
+import {
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  existsSync,
+  readdirSync,
+} from "node:fs";
+import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import { init } from "python-pptx-wasm";
 import { loadPyodide } from "pyodide";
@@ -26,6 +32,9 @@ interface FixtureEntry {
   imageResolver?: (src: string) => Uint8Array | undefined;
 }
 
+/** imageResolver が必要なフィクスチャ名のセット */
+const FIXTURES_REQUIRING_IMAGE_RESOLVER = new Set(["with-image"]);
+
 function buildPptx(
   mdContent: string,
   options?: { imageResolver?: (src: string) => Uint8Array | undefined },
@@ -36,6 +45,28 @@ function buildPptx(
   return generatePptx(parseResult, mappingResults, {
     imageResolver: options?.imageResolver,
   });
+}
+
+/** vrt/fixtures/ 内の .md ファイルと sample/sample.md からフィクスチャ一覧を自動生成する */
+function collectFixtures(
+  imageResolver: (src: string) => Uint8Array | undefined,
+): FixtureEntry[] {
+  const fixtures: FixtureEntry[] = readdirSync(VRT_FIXTURES)
+    .filter((f) => f.endsWith(".md"))
+    .sort()
+    .map((f) => {
+      const name = basename(f, ".md");
+      const entry: FixtureEntry = { name, mdPath: join(VRT_FIXTURES, f) };
+      if (FIXTURES_REQUIRING_IMAGE_RESOLVER.has(name)) {
+        entry.imageResolver = imageResolver;
+      }
+      return entry;
+    });
+
+  // sample/sample.md は vrt/fixtures/ 外にあるため個別追加
+  fixtures.push({ name: "sample", mdPath: join(SAMPLE_DIR, "sample.md") });
+
+  return fixtures;
 }
 
 async function main() {
@@ -56,36 +87,7 @@ async function main() {
     return undefined;
   };
 
-  const fixtures: FixtureEntry[] = [
-    { name: "basic", mdPath: join(VRT_FIXTURES, "basic.md") },
-    { name: "multi-slide", mdPath: join(VRT_FIXTURES, "multi-slide.md") },
-    {
-      name: "with-image",
-      mdPath: join(VRT_FIXTURES, "with-image.md"),
-      imageResolver,
-    },
-    {
-      name: "with-formatting",
-      mdPath: join(VRT_FIXTURES, "with-formatting.md"),
-    },
-    {
-      name: "heading-divider",
-      mdPath: join(VRT_FIXTURES, "heading-divider.md"),
-    },
-    {
-      name: "with-code-block",
-      mdPath: join(VRT_FIXTURES, "with-code-block.md"),
-    },
-    {
-      name: "with-table",
-      mdPath: join(VRT_FIXTURES, "with-table.md"),
-    },
-    {
-      name: "body-only",
-      mdPath: join(VRT_FIXTURES, "body-only.md"),
-    },
-    { name: "sample", mdPath: join(SAMPLE_DIR, "sample.md") },
-  ];
+  const fixtures = collectFixtures(imageResolver);
 
   for (const fixture of fixtures) {
     if (!existsSync(fixture.mdPath)) {

--- a/vrt/libreoffice/regression.test.ts
+++ b/vrt/libreoffice/regression.test.ts
@@ -19,16 +19,20 @@ const DIFF_DIR = join(__dirname, "diffs");
 const PIXEL_THRESHOLD = 0.3;
 const MISMATCH_TOLERANCE = 0.05;
 
-// テストケース定義
-const VRT_CASES = [
-  { name: "basic" },
-  { name: "multi-slide" },
-  { name: "with-image" },
-  { name: "with-formatting" },
-  { name: "heading-divider" },
-  { name: "with-code-block" },
-  { name: "sample" },
-] as const;
+/** snapshots/ と actual/ の PNG ファイルからフィクスチャ名を自動検出する（和集合） */
+function detectVrtCases(): { name: string }[] {
+  const names = new Set<string>();
+  for (const dir of [SNAPSHOT_DIR, ACTUAL_DIR]) {
+    if (!existsSync(dir)) continue;
+    for (const f of readdirSync(dir)) {
+      const match = f.match(/^(.+)-slide\d+\.png$/);
+      if (match) names.add(match[1]);
+    }
+  }
+  return [...names].sort().map((name) => ({ name }));
+}
+
+const VRT_CASES = detectVrtCases();
 
 /** actual/ ディレクトリから指定名のスライド PNG を収集する */
 function collectActualSlides(name: string): string[] {
@@ -55,9 +59,8 @@ describeOrSkip(
     for (const testCase of VRT_CASES) {
       const { name } = testCase;
       const actualSlides = collectActualSlides(name);
-      const snapshotSlide1 = join(SNAPSHOT_DIR, `${name}-slide1.png`);
-      const itOrSkip =
-        actualSlides.length > 0 && existsSync(snapshotSlide1) ? it : it.skip;
+      // actual がない場合のみスキップ（スナップショット未作成はテスト内で失敗させる）
+      const itOrSkip = actualSlides.length > 0 ? it : it.skip;
 
       describe(name, () => {
         itOrSkip("should match LibreOffice reference", () => {


### PR DESCRIPTION
close #108

## Summary

- `generate_fixtures.ts`: `vrt/fixtures/*.md` を `readdirSync` で自動収集し、手動の `fixtures` 配列を廃止。`imageResolver` が必要なフィクスチャは `FIXTURES_REQUIRING_IMAGE_RESOLVER` セットで管理。`sample/sample.md` は `vrt/fixtures/` 外のため個別追加。
- `regression.test.ts`: `VRT_CASES` の手動定義を廃止し、`snapshots/` と `actual/` の PNG ファイルからフィクスチャ名を自動検出（和集合）。`actual/` にあるがスナップショット未作成のケースはスキップではなくテスト失敗として検出。

## Test plan

- [x] `npm run lint` 通過
- [x] `npm run format:check` 通過
- [x] `npm run typecheck` 通過
- [x] `npm test` 通過（VRT テストは actual/snapshots 未生成のためスキップ）
- [ ] CI 通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)