### PR TITLE
chore: pptx-glimpse を 0.7.1 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "commander": "^14.0.3",
         "jszip": "^3.10.1",
         "markdown-it": "^14.1.1",
-        "pptx-glimpse": "^0.7.0",
+        "pptx-glimpse": "^0.7.1",
         "pyodide": "^0.28.3",
         "python-pptx-wasm": "^0.0.1"
       },
@@ -5010,9 +5010,9 @@
       }
     },
     "node_modules/pptx-glimpse": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/pptx-glimpse/-/pptx-glimpse-0.7.0.tgz",
-      "integrity": "sha512-VjMVUWyjbMIpug+pHkHHbgcDBrNEeZ2W+1LIUDjfqrbwI815jSkZ7/ScUH4/HQfGLLy7yJs+p02/WGxX2Uq0sQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/pptx-glimpse/-/pptx-glimpse-0.7.1.tgz",
+      "integrity": "sha512-GsSntQH3J0/86UviQG3jDX0ypLgQ/SiVJwNX3tFUTCkkPNZo+LIbVdx59HpSjWoztRqpyxINj0YthsSA2l2e5Q==",
       "license": "MIT",
       "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "commander": "^14.0.3",
     "jszip": "^3.10.1",
     "markdown-it": "^14.1.1",
-    "pptx-glimpse": "^0.7.0",
+    "pptx-glimpse": "^0.7.1",
     "pyodide": "^0.28.3",
     "python-pptx-wasm": "^0.0.1"
   },


### PR DESCRIPTION
## Summary
- pptx-glimpse の依存バージョンを `^0.7.0` → `0.7.1` にアップデート
- typecheck / build / test / lint / format すべてパス確認済み

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run build` パス
- [x] `npm run build:extension` パス
- [x] `npm test` 198 passed
- [x] `npm run lint` パス
- [x] `npm run format:check` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)